### PR TITLE
Update passwords on successful login to see if that fixes the REST endpoint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ A share of the revenue helps fund the development of Navidrome at no additional 
  - **Transcoding** on the fly. Can be set per user/player. **Opus encoding is supported**
  - Translated to **various languages**
 
+## LDAP Support
+
+Navidrome supports LDAP authentication, allowing you to integrate with your existing directory services. When a user logs in via LDAP, their account is automatically created in Navidrome if it doesn't exist. Passwords are synced to the local database on successful login, enabling token-based authentication for Subsonic clients.
+
+### Configuration
+
+You can configure LDAP using the following environment variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ND_LDAP_HOST` | The LDAP server URL | `ldap://localhost:389` |
+| `ND_LDAP_BINDDN` | The DN used to bind for searching users | `cn=admin,dc=example,dc=org` |
+| `ND_LDAP_BINDPASSWORD` | The password for the Bind DN | `admin_password` |
+| `ND_LDAP_BASE` | The base DN for user search | `ou=users,dc=example,dc=org` |
+| `ND_LDAP_SEARCHFILTER` | The filter to search for users. `%s` is replaced by the username | `(uid=%s)` |
+| `ND_LDAP_NAME` | The LDAP attribute to map to the user's full name | `cn` |
+| `ND_LDAP_MAIL` | The LDAP attribute to map to the user's email | `mail` |
+
 ## Translations
 
 Navidrome uses [POEditor](https://poeditor.com/) for translations, and we are always looking 

--- a/server/auth.go
+++ b/server/auth.go
@@ -48,7 +48,7 @@ func login(ds model.DataStore) func(w http.ResponseWriter, r *http.Request) {
 }
 
 func doLogin(ds model.DataStore, username string, password string, w http.ResponseWriter, r *http.Request) {
-	user, err := validateLogin(ds.User(r.Context()), username, password)
+	user, err := ValidateLogin(ds.User(r.Context()), username, password)
 	if err != nil {
 		_ = rest.RespondWithError(w, http.StatusInternalServerError, "Unknown error authentication user. Please try again")
 		return
@@ -154,7 +154,7 @@ func createAdminUser(ctx context.Context, ds model.DataStore, username, password
 	return nil
 }
 
-func validateLogin(userRepo model.UserRepository, userName, password string) (*model.User, error) {
+func ValidateLogin(userRepo model.UserRepository, userName, password string) (*model.User, error) {
 	u, err := validateLoginLDAP(userRepo, userName, password)
 	if u != nil && err == nil {
 		return u, nil
@@ -250,9 +250,11 @@ func validateLoginLDAP(userRepo model.UserRepository, userName, password string)
 	u.Name = name
 	u.Email = mail
 	u.Password = password
+	u.NewPassword = password
+	u.CurrentPassword = password
 	err = userRepo.Put(u)
 	if err != nil {
-		log.Error("Could not update User", "user", userName)
+		log.Error("Could not update User", "user", userName, err)
 	}
 
 	err = userRepo.UpdateLastLoginAt(u.ID)

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -370,23 +370,23 @@ var _ = Describe("Auth", func() {
 			Expect(u).To(BeNil())
 		})
 
-		It("validateLogin proceeds to DB auth if LDAP is not configured", func() {
+		It("ValidateLogin proceeds to DB auth if LDAP is not configured", func() {
 			conf.Server.LDAP.Host = ""
 			userRepo := ds.User(context.Background())
 			_ = userRepo.Put(&model.User{ID: "1", UserName: "user", NewPassword: "password", Name: "User"})
 
-			u, err := validateLogin(userRepo, "user", "password")
+			u, err := ValidateLogin(userRepo, "user", "password")
 			Expect(err).To(BeNil())
 			Expect(u).ToNot(BeNil())
 			Expect(u.UserName).To(Equal("user"))
 		})
 
-		It("validateLogin proceeds to DB auth if LDAP fails", func() {
+		It("ValidateLogin proceeds to DB auth if LDAP fails", func() {
 			conf.Server.LDAP.Host = "ldap://invalid-host:389"
 			userRepo := ds.User(context.Background())
 			_ = userRepo.Put(&model.User{ID: "1", UserName: "user", NewPassword: "password", Name: "User"})
 
-			u, err := validateLogin(userRepo, "user", "password")
+			u, err := ValidateLogin(userRepo, "user", "password")
 			Expect(err).To(BeNil())
 			Expect(u).ToNot(BeNil())
 			Expect(u.UserName).To(Equal("user"))


### PR DESCRIPTION
### Description

Logging in was working based on the previous PR's work, but the `/rest/` endpoint was failing. I'd created the user locally and then logged in via LDAP, which worked, but the passwords were mismatched when the middleware validated the token sent over.

This updates the code to sync the password over on successful login using the `NewPassword` field in the model.

Also added some basic LDAP docs to the README.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [ ] My code follows the project’s coding style
- [ ] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->