### PR TITLE
feat: per-device app passwords for Subsonic API clients

### DIFF
--- a/db/migrations/20260427000000_add_user_app_password.go
+++ b/db/migrations/20260427000000_add_user_app_password.go
@@ -1,0 +1,35 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddUserAppPassword, downAddUserAppPassword)
+}
+
+func upAddUserAppPassword(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS user_app_password (
+    id           VARCHAR PRIMARY KEY,
+    user_id      VARCHAR NOT NULL,
+    name         VARCHAR NOT NULL,
+    password     VARCHAR NOT NULL,
+    created_at   TIMESTAMP NOT NULL,
+    last_used_at TIMESTAMP,
+    revoked_at   TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+    UNIQUE (user_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_user_app_password_user_id ON user_app_password(user_id);
+`)
+	return err
+}
+
+func downAddUserAppPassword(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS user_app_password;`)
+	return err
+}

--- a/model/app_password.go
+++ b/model/app_password.go
@@ -1,0 +1,48 @@
+package model
+
+import "time"
+
+// AppPassword is a per-device credential a user can generate for use with
+// Subsonic API clients. It is independent of the user's main password (LDAP or
+// local) and can be revoked individually without affecting any other client or
+// the user's primary credentials.
+//
+// Password is the in-memory plaintext, populated only when the secret is
+// generated (Put) or fetched for authentication (FindActiveByUser). It is
+// never serialized to JSON. NewPassword carries the plaintext from caller to
+// repository on Put and is encrypted at rest, mirroring the User model.
+type AppPassword struct {
+	ID          string     `structs:"id" json:"id"`
+	UserID      string     `structs:"user_id" json:"userId"`
+	Name        string     `structs:"name" json:"name"`
+	Password    string     `structs:"-" json:"-"`
+	NewPassword string     `structs:"password,omitempty" json:"-"`
+	CreatedAt   time.Time  `structs:"created_at" json:"createdAt"`
+	LastUsedAt  *time.Time `structs:"last_used_at" json:"lastUsedAt,omitempty"`
+	RevokedAt   *time.Time `structs:"revoked_at" json:"revokedAt,omitempty"`
+}
+
+// IsActive reports whether the app password has not been revoked.
+func (a AppPassword) IsActive() bool {
+	return a.RevokedAt == nil
+}
+
+type AppPasswords []AppPassword
+
+// AppPasswordRepository persists per-device app passwords.
+//
+// Put creates the record (assigning ID/CreatedAt) and encrypts NewPassword in
+// place. List returns metadata only (no plaintext). FindActiveByUser returns
+// active records with Password decrypted, suitable for the Subsonic auth
+// fallback. Touch updates LastUsedAt to support last-used UI display. Revoke
+// performs a soft revocation (sets RevokedAt); the row remains so audit trails
+// and last-used timestamps survive.
+type AppPasswordRepository interface {
+	Put(ap *AppPassword) error
+	Get(id string) (*AppPassword, error)
+	List(userID string) (AppPasswords, error)
+	FindActiveByUser(userID string) (AppPasswords, error)
+	Revoke(id string) error
+	RevokeAllForUser(userID string) (int64, error)
+	Touch(id string) error
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -37,6 +37,7 @@ type DataStore interface {
 	Property(ctx context.Context) PropertyRepository
 	User(ctx context.Context) UserRepository
 	UserProps(ctx context.Context) UserPropsRepository
+	AppPassword(ctx context.Context) AppPasswordRepository
 	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
 	Scrobble(ctx context.Context) ScrobbleRepository
 	Plugin(ctx context.Context) PluginRepository

--- a/persistence/app_password_repository.go
+++ b/persistence/app_password_repository.go
@@ -147,7 +147,14 @@ func (r *appPasswordRepository) RevokeAllForUser(userID string) (int64, error) {
 }
 
 func (r *appPasswordRepository) Touch(idVal string) error {
-	upd := Update(r.tableName).Where(Eq{"id": idVal}).Set("last_used_at", time.Now())
+	// Filter on revoked_at to avoid bumping last_used_at on a revoked row
+	// under a TOCTOU race (a request mid-auth completing after another
+	// request revokes the same app password). Misleading audit data
+	// otherwise.
+	upd := Update(r.tableName).
+		Where(Eq{"id": idVal}).
+		Where(Eq{"revoked_at": nil}).
+		Set("last_used_at", time.Now())
 	_, err := r.executeSQL(upd)
 	return err
 }

--- a/persistence/app_password_repository.go
+++ b/persistence/app_password_repository.go
@@ -1,0 +1,155 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/id"
+	"github.com/navidrome/navidrome/utils"
+	"github.com/pocketbase/dbx"
+)
+
+type appPasswordRepository struct {
+	sqlRepository
+}
+
+func NewAppPasswordRepository(ctx context.Context, db dbx.Builder) model.AppPasswordRepository {
+	r := &appPasswordRepository{}
+	r.ctx = ctx
+	r.db = db
+	r.tableName = "user_app_password"
+	// Ensure the shared encryption key has been initialized. The user
+	// repository normally does this on first use; in code paths that touch
+	// app passwords before any user repository is constructed we need it
+	// here too.
+	once.Do(func() {
+		ur := &userRepository{}
+		ur.ctx = ctx
+		ur.db = db
+		ur.tableName = "user"
+		_ = ur.initPasswordEncryptionKey()
+	})
+	return r
+}
+
+func (r *appPasswordRepository) Put(ap *model.AppPassword) error {
+	if ap.UserID == "" {
+		return errors.New("user_id is required")
+	}
+	if ap.Name == "" {
+		return errors.New("name is required")
+	}
+	if ap.NewPassword == "" {
+		return errors.New("password is required")
+	}
+	if ap.ID == "" {
+		ap.ID = id.NewRandom()
+	}
+	if ap.CreatedAt.IsZero() {
+		ap.CreatedAt = time.Now()
+	}
+
+	encrypted, err := utils.Encrypt(r.ctx, encKey, ap.NewPassword)
+	if err != nil {
+		return fmt.Errorf("encrypting app password: %w", err)
+	}
+	plain := ap.NewPassword
+	ap.NewPassword = encrypted
+	defer func() {
+		// Restore the in-memory plaintext for the caller (one-time display)
+		// and clear NewPassword so it can't accidentally be reused.
+		ap.Password = plain
+		ap.NewPassword = ""
+	}()
+
+	values, err := toSQLArgs(*ap)
+	if err != nil {
+		return fmt.Errorf("converting app password to SQL args: %w", err)
+	}
+	insert := Insert(r.tableName).SetMap(values)
+	if _, err := r.executeSQL(insert); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *appPasswordRepository) Get(idVal string) (*model.AppPassword, error) {
+	sel := r.newSelect().Columns("*").Where(Eq{"id": idVal})
+	var res model.AppPassword
+	if err := r.queryOne(sel, &res); err != nil {
+		return nil, err
+	}
+	// Get is intended for callers who need metadata only (ownership checks,
+	// UI display). The encrypted blob never leaves the package — auth uses
+	// FindActiveByUser, which decrypts.
+	res.Password = ""
+	return &res, nil
+}
+
+func (r *appPasswordRepository) List(userID string) (model.AppPasswords, error) {
+	sel := r.newSelect().Columns("*").Where(Eq{"user_id": userID}).OrderBy("created_at DESC")
+	var res model.AppPasswords
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	// Never expose the encrypted blob via List — it's only used internally.
+	for i := range res {
+		res[i].Password = ""
+	}
+	return res, nil
+}
+
+func (r *appPasswordRepository) FindActiveByUser(userID string) (model.AppPasswords, error) {
+	sel := r.newSelect().Columns("*").
+		Where(Eq{"user_id": userID}).
+		Where(Eq{"revoked_at": nil})
+	var res model.AppPasswords
+	if err := r.queryAll(sel, &res); err != nil {
+		return nil, err
+	}
+	for i := range res {
+		plain, err := utils.Decrypt(r.ctx, encKey, res[i].Password)
+		if err != nil {
+			log.Error(r.ctx, "Error decrypting app password", "id", res[i].ID, "userID", userID, err)
+			continue
+		}
+		res[i].Password = plain
+	}
+	return res, nil
+}
+
+func (r *appPasswordRepository) Revoke(idVal string) error {
+	upd := Update(r.tableName).
+		Where(Eq{"id": idVal}).
+		Where(Eq{"revoked_at": nil}).
+		Set("revoked_at", time.Now())
+	count, err := r.executeSQL(upd)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return model.ErrNotFound
+	}
+	return nil
+}
+
+func (r *appPasswordRepository) RevokeAllForUser(userID string) (int64, error) {
+	upd := Update(r.tableName).
+		Where(Eq{"user_id": userID}).
+		Where(Eq{"revoked_at": nil}).
+		Set("revoked_at", time.Now())
+	return r.executeSQL(upd)
+}
+
+func (r *appPasswordRepository) Touch(idVal string) error {
+	upd := Update(r.tableName).Where(Eq{"id": idVal}).Set("last_used_at", time.Now())
+	_, err := r.executeSQL(upd)
+	return err
+}
+
+var _ model.AppPasswordRepository = (*appPasswordRepository)(nil)

--- a/persistence/app_password_repository_test.go
+++ b/persistence/app_password_repository_test.go
@@ -173,5 +173,17 @@ var _ = Describe("AppPasswordRepository", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(after.LastUsedAt).ToNot(BeNil())
 		})
+
+		It("does not bump last_used_at on a revoked password (TOCTOU guard)", func() {
+			ap := &model.AppPassword{UserID: owner.ID, Name: "revoked-touch", NewPassword: "x"}
+			Expect(repo.Put(ap)).To(Succeed())
+			Expect(repo.Revoke(ap.ID)).To(Succeed())
+
+			Expect(repo.Touch(ap.ID)).To(Succeed())
+
+			after, err := repo.Get(ap.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(after.LastUsedAt).To(BeNil())
+		})
 	})
 })

--- a/persistence/app_password_repository_test.go
+++ b/persistence/app_password_repository_test.go
@@ -1,0 +1,177 @@
+package persistence
+
+import (
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppPasswordRepository", func() {
+	var repo model.AppPasswordRepository
+	var userRepo model.UserRepository
+	var owner model.User
+
+	BeforeEach(func() {
+		ctx := log.NewContext(GinkgoT().Context())
+		userRepo = NewUserRepository(ctx, GetDBXBuilder())
+		owner = model.User{
+			ID:          "ap-test-owner",
+			UserName:    "ap-test-owner",
+			Name:        "AP Test Owner",
+			NewPassword: "irrelevant",
+		}
+		Expect(userRepo.Put(&owner)).To(Succeed())
+		repo = NewAppPasswordRepository(ctx, GetDBXBuilder())
+		// Wipe any leftover rows from previous specs since the persistence
+		// suite shares one in-memory SQLite database across all tests.
+		_, err := GetDBXBuilder().NewQuery("DELETE FROM user_app_password").Execute()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Put", func() {
+		It("creates a record, encrypts the secret, and exposes the plaintext on the input", func() {
+			ap := &model.AppPassword{
+				UserID:      owner.ID,
+				Name:        "iPhone Tempus",
+				NewPassword: "super-secret",
+			}
+			Expect(repo.Put(ap)).To(Succeed())
+			Expect(ap.ID).ToNot(BeEmpty())
+			Expect(ap.CreatedAt).ToNot(BeZero())
+			Expect(ap.Password).To(Equal("super-secret"))
+			Expect(ap.NewPassword).To(BeEmpty())
+
+			// Confirm the DB stored an encrypted blob, not the plaintext.
+			row, err := repo.Get(ap.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(row.Password).To(BeEmpty()) // Get scrubs the encrypted form
+			Expect(row.Name).To(Equal("iPhone Tempus"))
+		})
+
+		It("rejects records missing required fields", func() {
+			Expect(repo.Put(&model.AppPassword{Name: "n", NewPassword: "p"})).ToNot(Succeed())
+			Expect(repo.Put(&model.AppPassword{UserID: owner.ID, NewPassword: "p"})).ToNot(Succeed())
+			Expect(repo.Put(&model.AppPassword{UserID: owner.ID, Name: "n"})).ToNot(Succeed())
+		})
+
+		It("rejects duplicate names for the same user", func() {
+			a := &model.AppPassword{UserID: owner.ID, Name: "dup", NewPassword: "x"}
+			b := &model.AppPassword{UserID: owner.ID, Name: "dup", NewPassword: "y"}
+			Expect(repo.Put(a)).To(Succeed())
+			Expect(repo.Put(b)).ToNot(Succeed())
+		})
+	})
+
+	Describe("FindActiveByUser", func() {
+		It("returns active passwords with decrypted plaintext and excludes revoked ones", func() {
+			active := &model.AppPassword{UserID: owner.ID, Name: "active", NewPassword: "alpha"}
+			toRevoke := &model.AppPassword{UserID: owner.ID, Name: "old", NewPassword: "beta"}
+			Expect(repo.Put(active)).To(Succeed())
+			Expect(repo.Put(toRevoke)).To(Succeed())
+			Expect(repo.Revoke(toRevoke.ID)).To(Succeed())
+
+			results, err := repo.FindActiveByUser(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].ID).To(Equal(active.ID))
+			Expect(results[0].Password).To(Equal("alpha"))
+		})
+
+		It("returns empty for a user with no app passwords", func() {
+			results, err := repo.FindActiveByUser("no-such-user")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+	})
+
+	Describe("List", func() {
+		It("returns metadata for all of the user's records (including revoked) but never the encrypted blob", func() {
+			a := &model.AppPassword{UserID: owner.ID, Name: "list-a", NewPassword: "a"}
+			b := &model.AppPassword{UserID: owner.ID, Name: "list-b", NewPassword: "b"}
+			Expect(repo.Put(a)).To(Succeed())
+			Expect(repo.Put(b)).To(Succeed())
+			Expect(repo.Revoke(b.ID)).To(Succeed())
+
+			results, err := repo.List(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(2))
+			for _, r := range results {
+				Expect(r.Password).To(BeEmpty())
+			}
+		})
+	})
+
+	Describe("Revoke", func() {
+		It("marks an active password revoked", func() {
+			ap := &model.AppPassword{UserID: owner.ID, Name: "revoke-me", NewPassword: "x"}
+			Expect(repo.Put(ap)).To(Succeed())
+
+			Expect(repo.Revoke(ap.ID)).To(Succeed())
+
+			results, err := repo.FindActiveByUser(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("returns ErrNotFound for an unknown ID", func() {
+			Expect(repo.Revoke("does-not-exist")).To(MatchError(model.ErrNotFound))
+		})
+
+		It("returns ErrNotFound when revoking an already-revoked password", func() {
+			ap := &model.AppPassword{UserID: owner.ID, Name: "double-revoke", NewPassword: "x"}
+			Expect(repo.Put(ap)).To(Succeed())
+			Expect(repo.Revoke(ap.ID)).To(Succeed())
+			Expect(repo.Revoke(ap.ID)).To(MatchError(model.ErrNotFound))
+		})
+	})
+
+	Describe("RevokeAllForUser", func() {
+		It("revokes every active password for the user and reports the count", func() {
+			Expect(repo.Put(&model.AppPassword{UserID: owner.ID, Name: "all-1", NewPassword: "x"})).To(Succeed())
+			Expect(repo.Put(&model.AppPassword{UserID: owner.ID, Name: "all-2", NewPassword: "y"})).To(Succeed())
+			ap3 := &model.AppPassword{UserID: owner.ID, Name: "all-3", NewPassword: "z"}
+			Expect(repo.Put(ap3)).To(Succeed())
+			Expect(repo.Revoke(ap3.ID)).To(Succeed())
+
+			n, err := repo.RevokeAllForUser(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+
+			results, err := repo.FindActiveByUser(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("does not affect another user's passwords", func() {
+			otherOwner := model.User{ID: "ap-test-other", UserName: "ap-test-other", Name: "Other", NewPassword: "x"}
+			Expect(userRepo.Put(&otherOwner)).To(Succeed())
+			Expect(repo.Put(&model.AppPassword{UserID: owner.ID, Name: "mine", NewPassword: "x"})).To(Succeed())
+			Expect(repo.Put(&model.AppPassword{UserID: otherOwner.ID, Name: "theirs", NewPassword: "y"})).To(Succeed())
+
+			_, err := repo.RevokeAllForUser(owner.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			theirs, err := repo.FindActiveByUser(otherOwner.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(theirs).To(HaveLen(1))
+		})
+	})
+
+	Describe("Touch", func() {
+		It("bumps last_used_at", func() {
+			ap := &model.AppPassword{UserID: owner.ID, Name: "touchable", NewPassword: "x"}
+			Expect(repo.Put(ap)).To(Succeed())
+
+			before, err := repo.Get(ap.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(before.LastUsedAt).To(BeNil())
+
+			Expect(repo.Touch(ap.ID)).To(Succeed())
+
+			after, err := repo.Get(ap.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(after.LastUsedAt).ToNot(BeNil())
+		})
+	})
+})

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -77,6 +77,10 @@ func (s *SQLStore) User(ctx context.Context) model.UserRepository {
 	return NewUserRepository(ctx, s.getDBXBuilder())
 }
 
+func (s *SQLStore) AppPassword(ctx context.Context) model.AppPasswordRepository {
+	return NewAppPasswordRepository(ctx, s.getDBXBuilder())
+}
+
 func (s *SQLStore) Transcoding(ctx context.Context) model.TranscodingRepository {
 	return NewTranscodingRepository(ctx, s.getDBXBuilder())
 }

--- a/server/nativeapi/app_password.go
+++ b/server/nativeapi/app_password.go
@@ -1,0 +1,234 @@
+package nativeapi
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+// appPasswordSecretBytes is the entropy of a generated app password before
+// base64 encoding. 32 bytes = 256 bits, comfortably above any salt+token
+// guessing budget.
+const appPasswordSecretBytes = 32
+
+// User-app-password endpoints. A user (or an admin) can list, create, and
+// revoke app passwords for any user. The plaintext secret is returned only
+// once, on creation.
+func (api *Router) addAppPasswordRoute(r chi.Router) {
+	r.Route("/user/{id}/app-password", func(r chi.Router) {
+		r.Use(parseUserIDMiddleware)
+		r.Use(appPasswordAccessMiddleware)
+		r.Get("/", listAppPasswords(api.ds))
+		r.Post("/", createAppPassword(api.ds))
+		r.Delete("/", revokeAllAppPasswords(api.ds))
+		r.Route("/{appPasswordId}", func(r chi.Router) {
+			r.Delete("/", revokeAppPassword(api.ds))
+		})
+	})
+}
+
+// appPasswordAccessMiddleware authorizes the request: the caller must either
+// be the user being managed or an admin.
+func appPasswordAccessMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, _ := r.Context().Value("userID").(string) //nolint:staticcheck // matches existing parseUserIDMiddleware
+		caller, ok := request.UserFrom(r.Context())
+		if !ok {
+			http.Error(w, "Not authenticated", http.StatusUnauthorized)
+			return
+		}
+		if !caller.IsAdmin && caller.ID != userID {
+			http.Error(w, "Access denied", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func listAppPasswords(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userID := ctx.Value("userID").(string) //nolint:staticcheck
+
+		if _, err := ds.User(ctx).Get(userID); err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "User not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Error loading user", "userID", userID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		items, err := ds.AppPassword(ctx).List(userID)
+		if err != nil {
+			log.Error(ctx, "Error listing app passwords", "userID", userID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		if items == nil {
+			items = model.AppPasswords{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(items); err != nil {
+			log.Error(ctx, "Error encoding app password list response", err)
+		}
+	}
+}
+
+func createAppPassword(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userID := ctx.Value("userID").(string) //nolint:staticcheck
+
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+		if body.Name == "" {
+			http.Error(w, "name is required", http.StatusBadRequest)
+			return
+		}
+
+		if _, err := ds.User(ctx).Get(userID); err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "User not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Error loading user", "userID", userID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		secret, err := generateAppPasswordSecret()
+		if err != nil {
+			log.Error(ctx, "Error generating app password secret", "userID", userID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		ap := &model.AppPassword{
+			UserID:      userID,
+			Name:        body.Name,
+			NewPassword: secret,
+		}
+		if err := ds.AppPassword(ctx).Put(ap); err != nil {
+			log.Error(ctx, "Error creating app password", "userID", userID, "name", body.Name, err)
+			http.Error(w, "Failed to create app password", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		// Plaintext secret is returned ONCE, here. After this response, the
+		// only retrievable form is the encrypted password used by the auth
+		// flow itself. (gosec G117 flags any "secret" field in a response;
+		// this is the deliberate one-time-display, the rest of the API never
+		// exposes it.)
+		resp := struct {
+			ID        string `json:"id"`
+			UserID    string `json:"userId"`
+			Name      string `json:"name"`
+			Secret    string `json:"secret"` //nolint:gosec // intentional one-time return
+			CreatedAt string `json:"createdAt"`
+		}{
+			ID:        ap.ID,
+			UserID:    ap.UserID,
+			Name:      ap.Name,
+			Secret:    secret,
+			CreatedAt: ap.CreatedAt.Format("2006-01-02T15:04:05.000Z"),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil { //nolint:gosec // Secret field returned by design (one-time display)
+			log.Error(ctx, "Error encoding app password create response", err)
+		}
+	}
+}
+
+func revokeAppPassword(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userID := ctx.Value("userID").(string) //nolint:staticcheck
+		appPasswordID := chi.URLParam(r, "appPasswordId")
+		if appPasswordID == "" {
+			http.Error(w, "Invalid app password ID", http.StatusBadRequest)
+			return
+		}
+
+		// Make sure the app password belongs to the user from the URL — this
+		// prevents an admin from accidentally revoking someone else's app
+		// password by hitting /user/$other/app-password/$id.
+		ap, err := ds.AppPassword(ctx).Get(appPasswordID)
+		if err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "App password not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Error loading app password", "id", appPasswordID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		if ap.UserID != userID {
+			http.Error(w, "App password not found", http.StatusNotFound)
+			return
+		}
+
+		if err := ds.AppPassword(ctx).Revoke(appPasswordID); err != nil {
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, "App password not found", http.StatusNotFound)
+				return
+			}
+			log.Error(ctx, "Error revoking app password", "id", appPasswordID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(struct {
+			ID string `json:"id"`
+		}{ID: appPasswordID}); err != nil {
+			log.Error(ctx, "Error encoding revoke response", err)
+		}
+	}
+}
+
+func revokeAllAppPasswords(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		userID := ctx.Value("userID").(string) //nolint:staticcheck
+
+		count, err := ds.AppPassword(ctx).RevokeAllForUser(userID)
+		if err != nil {
+			log.Error(ctx, "Error revoking all app passwords", "userID", userID, err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(struct {
+			Revoked int64 `json:"revoked"`
+		}{Revoked: count}); err != nil {
+			log.Error(ctx, "Error encoding revoke-all response", err)
+		}
+	}
+}
+
+// generateAppPasswordSecret returns a URL-safe random secret. The output is
+// base64-encoded so it can be pasted into Subsonic clients that don't accept
+// arbitrary bytes; the underlying entropy is appPasswordSecretBytes * 8 bits.
+func generateAppPasswordSecret() (string, error) {
+	buf := make([]byte, appPasswordSecretBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/server/nativeapi/app_password_test.go
+++ b/server/nativeapi/app_password_test.go
@@ -1,0 +1,219 @@
+package nativeapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/core/auth"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("App Password API", func() {
+	var ds model.DataStore
+	var router http.Handler
+	var adminUser, ownerUser, otherUser model.User
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		ds = &tests.MockDataStore{}
+		auth.Init(ds)
+		nativeRouter := New(ds, nil, nil, nil, tests.NewMockLibraryService(), tests.NewMockUserService(), nil, nil, nil)
+		router = server.JWTVerifier(nativeRouter)
+
+		adminUser = model.User{ID: "admin-1", UserName: "admin", Name: "Admin", IsAdmin: true, NewPassword: "p"}
+		ownerUser = model.User{ID: "user-1", UserName: "owner", Name: "Owner", IsAdmin: false, NewPassword: "p"}
+		otherUser = model.User{ID: "user-2", UserName: "other", Name: "Other", IsAdmin: false, NewPassword: "p"}
+
+		Expect(ds.User(context.TODO()).Put(&adminUser)).To(Succeed())
+		Expect(ds.User(context.TODO()).Put(&ownerUser)).To(Succeed())
+		Expect(ds.User(context.TODO()).Put(&otherUser)).To(Succeed())
+	})
+
+	tokenFor := func(u *model.User) string {
+		t, err := auth.CreateToken(u)
+		Expect(err).ToNot(HaveOccurred())
+		return t
+	}
+
+	Describe("POST /api/user/{id}/app-password", func() {
+		It("creates an app password for the owner and returns the secret once", func() {
+			body := bytes.NewBufferString(`{"name":"iPhone Tempus"}`)
+			req := createAuthenticatedRequest("POST", "/user/user-1/app-password", body, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+			var resp map[string]any
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["id"]).ToNot(BeEmpty())
+			Expect(resp["userId"]).To(Equal("user-1"))
+			Expect(resp["name"]).To(Equal("iPhone Tempus"))
+			Expect(resp["secret"]).ToNot(BeEmpty())
+		})
+
+		It("lets an admin create on behalf of any user", func() {
+			body := bytes.NewBufferString(`{"name":"admin-created"}`)
+			req := createAuthenticatedRequest("POST", "/user/user-1/app-password", body, tokenFor(&adminUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+		})
+
+		It("forbids a non-admin from creating for another user", func() {
+			body := bytes.NewBufferString(`{"name":"sneaky"}`)
+			req := createAuthenticatedRequest("POST", "/user/user-2/app-password", body, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusForbidden))
+		})
+
+		It("rejects requests without a name", func() {
+			body := bytes.NewBufferString(`{}`)
+			req := createAuthenticatedRequest("POST", "/user/user-1/app-password", body, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns 401 when unauthenticated", func() {
+			body := bytes.NewBufferString(`{"name":"x"}`)
+			req := createUnauthenticatedRequest("POST", "/user/user-1/app-password", body)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	Describe("GET /api/user/{id}/app-password", func() {
+		It("returns the user's own list", func() {
+			Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{
+				UserID: "user-1", Name: "list-me", NewPassword: "secret",
+			})).To(Succeed())
+
+			req := createAuthenticatedRequest("GET", "/user/user-1/app-password", nil, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring("list-me"))
+			// Plaintext secret must never appear in a list response.
+			Expect(w.Body.String()).ToNot(ContainSubstring("secret"))
+		})
+
+		It("forbids a non-admin from listing another user's passwords", func() {
+			req := createAuthenticatedRequest("GET", "/user/user-2/app-password", nil, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusForbidden))
+		})
+
+		It("lets an admin list for any user", func() {
+			req := createAuthenticatedRequest("GET", "/user/user-1/app-password", nil, tokenFor(&adminUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+		})
+	})
+
+	Describe("DELETE /api/user/{id}/app-password/{appId}", func() {
+		It("revokes the password when called by the owner", func() {
+			ap := &model.AppPassword{UserID: "user-1", Name: "to-revoke", NewPassword: "x"}
+			Expect(ds.AppPassword(context.TODO()).Put(ap)).To(Succeed())
+
+			req := createAuthenticatedRequest("DELETE", "/user/user-1/app-password/"+ap.ID, nil, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			active, err := ds.AppPassword(context.TODO()).FindActiveByUser("user-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(active).To(BeEmpty())
+		})
+
+		It("rejects a path mismatch where the password belongs to a different user", func() {
+			ap := &model.AppPassword{UserID: "user-2", Name: "their-pw", NewPassword: "x"}
+			Expect(ds.AppPassword(context.TODO()).Put(ap)).To(Succeed())
+
+			// Admin tries to revoke user-2's password via a /user/user-1/... path.
+			// This should 404 because the password isn't owned by user-1.
+			req := createAuthenticatedRequest("DELETE", "/user/user-1/app-password/"+ap.ID, nil, tokenFor(&adminUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+
+			active, err := ds.AppPassword(context.TODO()).FindActiveByUser("user-2")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(active).To(HaveLen(1))
+		})
+
+		It("returns 404 when the app password ID is unknown", func() {
+			req := createAuthenticatedRequest("DELETE", "/user/user-1/app-password/does-not-exist", nil, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("DELETE /api/user/{id}/app-password (revoke all)", func() {
+		It("revokes every active password for the user", func() {
+			Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{UserID: "user-1", Name: "a", NewPassword: "x"})).To(Succeed())
+			Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{UserID: "user-1", Name: "b", NewPassword: "y"})).To(Succeed())
+
+			req := createAuthenticatedRequest("DELETE", "/user/user-1/app-password", nil, tokenFor(&ownerUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring(`"revoked":2`))
+
+			active, err := ds.AppPassword(context.TODO()).FindActiveByUser("user-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(active).To(BeEmpty())
+		})
+	})
+
+	Describe("response shape", func() {
+		It("never leaks the encrypted password blob via list", func() {
+			ap := &model.AppPassword{UserID: "user-1", Name: "blobby", NewPassword: "the-secret-value"}
+			Expect(ds.AppPassword(context.TODO()).Put(ap)).To(Succeed())
+
+			req := createAuthenticatedRequest("GET", "/user/user-1/app-password", nil, tokenFor(&adminUser))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(strings.Contains(w.Body.String(), "the-secret-value")).To(BeFalse())
+		})
+	})
+})

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -84,6 +84,7 @@ func (api *Router) routes() http.Handler {
 		api.addMissingFilesRoute(r)
 		api.addKeepAliveRoute(r)
 		api.addInsightsRoute(r)
+		api.addAppPasswordRoute(r)
 
 		r.With(adminOnlyMiddleware).Group(func(r chi.Router) {
 			api.addInspectRoute(r)

--- a/server/subsonic/app_password_auth_test.go
+++ b/server/subsonic/app_password_auth_test.go
@@ -1,0 +1,165 @@
+package subsonic
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"net/http/httptest"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("App Password Subsonic Auth", func() {
+	var ds *tests.MockDataStore
+	var w *httptest.ResponseRecorder
+	var nextHandler *mockHandler
+	const username = "alice"
+	const userID = "uid-alice"
+	const mainPassword = "alice-main"
+	const appSecret = "tempus-on-iphone-secret"
+
+	BeforeEach(func() {
+		nextHandler = &mockHandler{}
+		w = httptest.NewRecorder()
+		ds = &tests.MockDataStore{}
+
+		Expect(ds.User(context.TODO()).Put(&model.User{
+			ID:          userID,
+			UserName:    username,
+			NewPassword: mainPassword,
+		})).To(Succeed())
+		Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{
+			UserID:      userID,
+			Name:        "iPhone",
+			NewPassword: appSecret,
+		})).To(Succeed())
+	})
+
+	When("the client sends a legacy password (`p=`)", func() {
+		It("accepts the main password", func() {
+			r := newGetRequest("u="+username, "p="+mainPassword)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+			user, _ := request.UserFrom(nextHandler.req.Context())
+			Expect(user.UserName).To(Equal(username))
+		})
+
+		It("accepts an active app password as a fallback", func() {
+			r := newGetRequest("u="+username, "p="+appSecret)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+			user, _ := request.UserFrom(nextHandler.req.Context())
+			Expect(user.UserName).To(Equal(username))
+		})
+
+		It("rejects an unknown secret", func() {
+			r := newGetRequest("u="+username, "p=not-the-right-secret")
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeFalse())
+			Expect(w.Body.String()).To(ContainSubstring(`code="40"`))
+		})
+
+		It("rejects a revoked app password", func() {
+			active, err := ds.AppPassword(context.TODO()).FindActiveByUser(userID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(active).To(HaveLen(1))
+			Expect(ds.AppPassword(context.TODO()).Revoke(active[0].ID)).To(Succeed())
+
+			r := newGetRequest("u="+username, "p="+appSecret)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeFalse())
+			Expect(w.Body.String()).To(ContainSubstring(`code="40"`))
+		})
+	})
+
+	When("the client sends salt+token (`t=`/`s=`)", func() {
+		const salt = "saltysalt"
+
+		It("accepts the main password's token", func() {
+			token := fmt.Sprintf("%x", md5.Sum([]byte(mainPassword+salt)))
+			r := newGetRequest("u="+username, "t="+token, "s="+salt)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+		})
+
+		It("accepts an app password's token as a fallback", func() {
+			token := fmt.Sprintf("%x", md5.Sum([]byte(appSecret+salt)))
+			r := newGetRequest("u="+username, "t="+token, "s="+salt)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+			user, _ := request.UserFrom(nextHandler.req.Context())
+			Expect(user.UserName).To(Equal(username))
+		})
+
+		It("rejects when neither the main password nor any app password matches", func() {
+			token := fmt.Sprintf("%x", md5.Sum([]byte("nope"+salt)))
+			r := newGetRequest("u="+username, "t="+token, "s="+salt)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeFalse())
+			Expect(w.Body.String()).To(ContainSubstring(`code="40"`))
+		})
+
+		It("rejects revoked app password tokens", func() {
+			active, err := ds.AppPassword(context.TODO()).FindActiveByUser(userID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ds.AppPassword(context.TODO()).Revoke(active[0].ID)).To(Succeed())
+
+			token := fmt.Sprintf("%x", md5.Sum([]byte(appSecret+salt)))
+			r := newGetRequest("u="+username, "t="+token, "s="+salt)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeFalse())
+		})
+	})
+
+	When("the user has no app passwords", func() {
+		It("does not interfere with main-password auth", func() {
+			Expect(ds.User(context.TODO()).Put(&model.User{
+				ID:          "uid-bob",
+				UserName:    "bob",
+				NewPassword: "bobpw",
+			})).To(Succeed())
+
+			r := newGetRequest("u=bob", "p=bobpw")
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+		})
+
+		It("rejects an invalid main password without trying app passwords", func() {
+			Expect(ds.User(context.TODO()).Put(&model.User{
+				ID:          "uid-bob",
+				UserName:    "bob",
+				NewPassword: "bobpw",
+			})).To(Succeed())
+
+			r := newGetRequest("u=bob", "p=wrong")
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeFalse())
+		})
+	})
+
+	It("bumps last_used_at on a successful app-password auth", func() {
+		token := fmt.Sprintf("%x", md5.Sum([]byte(appSecret+"saltysalt")))
+		r := newGetRequest("u="+username, "t="+token, "s=saltysalt")
+		authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+		Expect(nextHandler.called).To(BeTrue())
+		all, err := ds.AppPassword(context.TODO()).List(userID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(all).To(HaveLen(1))
+		Expect(all[0].LastUsedAt).ToNot(BeNil())
+	})
+})

--- a/server/subsonic/app_password_auth_test.go
+++ b/server/subsonic/app_password_auth_test.go
@@ -182,20 +182,21 @@ var _ = Describe("App Password Subsonic Auth", func() {
 
 	// Regression for the single-decode invariant. The parent flow decodes
 	// `p=enc:<hex>` once into plaintext; matchAppPassword must not decode
-	// again. A secret whose plaintext literally starts with `enc:` followed
-	// by hex would otherwise be mishandled by a double-decode.
+	// again. A password whose plaintext literally starts with `enc:`
+	// followed by hex would otherwise be mishandled by a double-decode.
 	It("matches an app password whose plaintext starts with `enc:`", func() {
-		const trickySecret = "enc:6162" // plaintext, not hex-encoded
+		// Plaintext that looks like an `enc:`-encoded value but isn't.
+		const trickyPlaintext = "enc:6162"
 		Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{
 			UserID:      userID,
 			Name:        "tricky",
-			NewPassword: trickySecret,
+			NewPassword: trickyPlaintext,
 		})).To(Succeed())
 
 		// hex-encode the literal string "enc:6162" so the parent flow
 		// decodes it once into the plaintext. A buggy double-decode would
 		// take the decoded "enc:6162" and decode again to "ab".
-		hexEncoded := fmt.Sprintf("%x", []byte(trickySecret))
+		hexEncoded := fmt.Sprintf("%x", []byte(trickyPlaintext))
 		r := newGetRequest("u="+username, "p=enc:"+hexEncoded)
 		authenticate(ds)(nextHandler).ServeHTTP(w, r)
 

--- a/server/subsonic/app_password_auth_test.go
+++ b/server/subsonic/app_password_auth_test.go
@@ -162,4 +162,43 @@ var _ = Describe("App Password Subsonic Auth", func() {
 		Expect(all).To(HaveLen(1))
 		Expect(all[0].LastUsedAt).ToNot(BeNil())
 	})
+
+	// Regression: app-password auth must short-circuit BEFORE
+	// `server.ValidateLogin` is called. ValidateLogin attempts a real LDAP
+	// bind and, on success, bumps LastLoginAt. If app-password auth runs
+	// before ValidateLogin (the intended order), neither LDAP nor
+	// LastLoginAt is touched.
+	It("does not bump LastLoginAt when authenticating via app password (LDAP-skip)", func() {
+		r := newGetRequest("u="+username, "p="+appSecret)
+		authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+		Expect(nextHandler.called).To(BeTrue())
+		usr, err := ds.User(context.TODO()).FindByUsername(username)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(usr.LastLoginAt).To(BeNil(),
+			"LastLoginAt should not be set — that would mean ValidateLogin "+
+				"ran, which means LDAP would have been queried")
+	})
+
+	// Regression for the single-decode invariant. The parent flow decodes
+	// `p=enc:<hex>` once into plaintext; matchAppPassword must not decode
+	// again. A secret whose plaintext literally starts with `enc:` followed
+	// by hex would otherwise be mishandled by a double-decode.
+	It("matches an app password whose plaintext starts with `enc:`", func() {
+		const trickySecret = "enc:6162" // plaintext, not hex-encoded
+		Expect(ds.AppPassword(context.TODO()).Put(&model.AppPassword{
+			UserID:      userID,
+			Name:        "tricky",
+			NewPassword: trickySecret,
+		})).To(Succeed())
+
+		// hex-encode the literal string "enc:6162" so the parent flow
+		// decodes it once into the plaintext. A buggy double-decode would
+		// take the decoded "enc:6162" and decode again to "ab".
+		hexEncoded := fmt.Sprintf("%x", []byte(trickySecret))
+		r := newGetRequest("u="+username, "p=enc:"+hexEncoded)
+		authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+		Expect(nextHandler.called).To(BeTrue())
+	})
 })

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -157,6 +157,24 @@ func authenticate(ds model.DataStore) func(next http.Handler) http.Handler {
 						}
 					}
 				}
+
+				// App-password fallback. If the regular credential check
+				// failed, try matching the presented credentials against the
+				// user's active app passwords. App passwords are per-device,
+				// revocable secrets independent of the user's main password
+				// (LDAP or local). Only password and salt+token auth are
+				// considered; JWT auth carries its own user identity, and
+				// internal/reverse-proxy auth bypasses the credential check
+				// entirely.
+				if err != nil && jwt == "" && (pass != "" || token != "") {
+					if appUsr, appID, ok := matchAppPassword(ctx, ds, username, pass, token, salt); ok {
+						usr = appUsr
+						err = nil
+						if touchErr := ds.AppPassword(ctx).Touch(appID); touchErr != nil {
+							log.Warn(ctx, "API: Failed to bump app password last_used_at", "id", appID, "username", username, touchErr)
+						}
+					}
+				}
 			}
 
 			if err != nil {
@@ -193,6 +211,40 @@ func validateCredentials(user *model.User, pass, token, salt, jwt string) error 
 		return model.ErrInvalidAuth
 	}
 	return nil
+}
+
+// matchAppPassword tries to authenticate the request against the user's
+// active app passwords. Returns the user, the matched app password ID, and
+// true on success. The caller is responsible for bumping last_used_at on
+// the returned ID. The user is looked up fresh because the prior auth path
+// may have failed before populating it.
+func matchAppPassword(ctx context.Context, ds model.DataStore, username, pass, token, salt string) (*model.User, string, bool) {
+	if username == "" {
+		return nil, "", false
+	}
+	usr, err := ds.User(ctx).FindByUsername(username)
+	if err != nil {
+		return nil, "", false
+	}
+	active, err := ds.AppPassword(ctx).FindActiveByUser(usr.ID)
+	if err != nil {
+		log.Warn(ctx, "API: Error loading app passwords", "username", username, err)
+		return nil, "", false
+	}
+	if strings.HasPrefix(pass, "enc:") {
+		if dec, decErr := hex.DecodeString(pass[4:]); decErr == nil {
+			pass = string(dec)
+		}
+	}
+	for _, ap := range active {
+		switch {
+		case pass != "" && pass == ap.Password:
+			return usr, ap.ID, true
+		case token != "" && fmt.Sprintf("%x", md5.Sum([]byte(ap.Password+salt))) == token:
+			return usr, ap.ID, true
+		}
+	}
+	return nil, "", false
 }
 
 func getPlayer(players core.Players) func(next http.Handler) http.Handler {

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -131,6 +131,25 @@ func authenticate(ds model.DataStore) func(next http.Handler) http.Handler {
 				salt, _ := p.String("s")
 				jwt, _ := p.String("jwt")
 
+				// App-password fast path. When the request carries a `p` or
+				// salt+token, try matching against the user's active app
+				// passwords FIRST. This avoids hitting LDAP on every Subsonic
+				// request from a client using an app password — which is the
+				// whole point of decoupling Subsonic auth from the directory.
+				// LDAP deployments with lockout policies (AD lockoutThreshold,
+				// FreeIPA password policy) would otherwise lock the user's
+				// directory account on every legitimate app-password request.
+				if jwt == "" && (pass != "" || token != "") {
+					if appUsr, appID, ok := matchAppPassword(ctx, ds, username, pass, token, salt); ok {
+						if touchErr := ds.AppPassword(ctx).Touch(appID); touchErr != nil {
+							log.Warn(ctx, "API: Failed to bump app password last_used_at", "id", appID, "username", username, touchErr)
+						}
+						ctx = request.WithUser(ctx, *appUsr)
+						next.ServeHTTP(w, r.WithContext(ctx))
+						return
+					}
+				}
+
 				if pass != "" {
 					usr, err = server.ValidateLogin(ds.User(ctx), username, pass)
 					if err == nil && usr == nil {
@@ -154,24 +173,6 @@ func authenticate(ds model.DataStore) func(next http.Handler) http.Handler {
 						err = validateCredentials(usr, pass, token, salt, jwt)
 						if err != nil {
 							log.Warn(ctx, "API: Invalid login", "auth", "subsonic", "username", username, "remoteAddr", r.RemoteAddr, err)
-						}
-					}
-				}
-
-				// App-password fallback. If the regular credential check
-				// failed, try matching the presented credentials against the
-				// user's active app passwords. App passwords are per-device,
-				// revocable secrets independent of the user's main password
-				// (LDAP or local). Only password and salt+token auth are
-				// considered; JWT auth carries its own user identity, and
-				// internal/reverse-proxy auth bypasses the credential check
-				// entirely.
-				if err != nil && jwt == "" && (pass != "" || token != "") {
-					if appUsr, appID, ok := matchAppPassword(ctx, ds, username, pass, token, salt); ok {
-						usr = appUsr
-						err = nil
-						if touchErr := ds.AppPassword(ctx).Touch(appID); touchErr != nil {
-							log.Warn(ctx, "API: Failed to bump app password last_used_at", "id", appID, "username", username, touchErr)
 						}
 					}
 				}
@@ -216,8 +217,8 @@ func validateCredentials(user *model.User, pass, token, salt, jwt string) error 
 // matchAppPassword tries to authenticate the request against the user's
 // active app passwords. Returns the user, the matched app password ID, and
 // true on success. The caller is responsible for bumping last_used_at on
-// the returned ID. The user is looked up fresh because the prior auth path
-// may have failed before populating it.
+// the returned ID. `pass` MUST already be the decoded plaintext (the parent
+// `authenticate` flow handles `enc:` decoding once); we do not decode again.
 func matchAppPassword(ctx context.Context, ds model.DataStore, username, pass, token, salt string) (*model.User, string, bool) {
 	if username == "" {
 		return nil, "", false
@@ -230,11 +231,6 @@ func matchAppPassword(ctx context.Context, ds model.DataStore, username, pass, t
 	if err != nil {
 		log.Warn(ctx, "API: Error loading app passwords", "username", username, err)
 		return nil, "", false
-	}
-	if strings.HasPrefix(pass, "enc:") {
-		if dec, decErr := hex.DecodeString(pass[4:]); decErr == nil {
-			pass = string(dec)
-		}
 	}
 	for _, ap := range active {
 		switch {

--- a/tests/mock_app_password_repo.go
+++ b/tests/mock_app_password_repo.go
@@ -137,6 +137,10 @@ func (m *MockedAppPasswordRepo) Touch(id string) error {
 	if !ok {
 		return model.ErrNotFound
 	}
+	if ap.RevokedAt != nil {
+		// Mirror the real repo: don't bump last_used_at on revoked rows.
+		return nil
+	}
 	ap.LastUsedAt = gg.P(time.Now())
 	return nil
 }

--- a/tests/mock_app_password_repo.go
+++ b/tests/mock_app_password_repo.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"sync"
+	"time"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/gg"
+)
+
+func CreateMockAppPasswordRepo() *MockedAppPasswordRepo {
+	return &MockedAppPasswordRepo{
+		Data: map[string]*model.AppPassword{},
+	}
+}
+
+type MockedAppPasswordRepo struct {
+	mu    sync.Mutex
+	Error error
+	// Data maps app password ID to the stored entity. Stored entities use
+	// the same plaintext for Password and NewPassword (no encryption in
+	// the mock) so tests can compare directly.
+	Data map[string]*model.AppPassword
+}
+
+func (m *MockedAppPasswordRepo) Put(ap *model.AppPassword) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return m.Error
+	}
+	if ap.ID == "" {
+		ap.ID = ap.UserID + ":" + ap.Name
+	}
+	if ap.CreatedAt.IsZero() {
+		ap.CreatedAt = time.Now()
+	}
+	plain := ap.NewPassword
+	stored := *ap
+	stored.Password = plain
+	stored.NewPassword = ""
+	m.Data[ap.ID] = &stored
+	ap.Password = plain
+	ap.NewPassword = ""
+	return nil
+}
+
+func (m *MockedAppPasswordRepo) Get(id string) (*model.AppPassword, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	ap, ok := m.Data[id]
+	if !ok {
+		return nil, model.ErrNotFound
+	}
+	cp := *ap
+	cp.Password = ""
+	return &cp, nil
+}
+
+func (m *MockedAppPasswordRepo) List(userID string) (model.AppPasswords, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	var out model.AppPasswords
+	for _, ap := range m.Data {
+		if ap.UserID != userID {
+			continue
+		}
+		cp := *ap
+		cp.Password = ""
+		out = append(out, cp)
+	}
+	return out, nil
+}
+
+func (m *MockedAppPasswordRepo) FindActiveByUser(userID string) (model.AppPasswords, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	var out model.AppPasswords
+	for _, ap := range m.Data {
+		if ap.UserID != userID || ap.RevokedAt != nil {
+			continue
+		}
+		out = append(out, *ap)
+	}
+	return out, nil
+}
+
+func (m *MockedAppPasswordRepo) Revoke(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return m.Error
+	}
+	ap, ok := m.Data[id]
+	if !ok {
+		return model.ErrNotFound
+	}
+	if ap.RevokedAt != nil {
+		return model.ErrNotFound
+	}
+	ap.RevokedAt = gg.P(time.Now())
+	return nil
+}
+
+func (m *MockedAppPasswordRepo) RevokeAllForUser(userID string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return 0, m.Error
+	}
+	var n int64
+	for _, ap := range m.Data {
+		if ap.UserID == userID && ap.RevokedAt == nil {
+			ap.RevokedAt = gg.P(time.Now())
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *MockedAppPasswordRepo) Touch(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Error != nil {
+		return m.Error
+	}
+	ap, ok := m.Data[id]
+	if !ok {
+		return model.ErrNotFound
+	}
+	ap.LastUsedAt = gg.P(time.Now())
+	return nil
+}

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -17,6 +17,7 @@ type MockDataStore struct {
 	MockedMediaFile      model.MediaFileRepository
 	MockedTag            model.TagRepository
 	MockedUser           model.UserRepository
+	MockedAppPassword    model.AppPasswordRepository
 	MockedProperty       model.PropertyRepository
 	MockedPlayer         model.PlayerRepository
 	MockedPlaylist       model.PlaylistRepository
@@ -178,6 +179,17 @@ func (db *MockDataStore) User(ctx context.Context) model.UserRepository {
 	}
 	db.MockedUser = CreateMockUserRepo()
 	return db.MockedUser
+}
+
+func (db *MockDataStore) AppPassword(ctx context.Context) model.AppPasswordRepository {
+	if db.MockedAppPassword != nil {
+		return db.MockedAppPassword
+	}
+	if db.RealDS != nil {
+		return db.RealDS.AppPassword(ctx)
+	}
+	db.MockedAppPassword = CreateMockAppPasswordRepo()
+	return db.MockedAppPassword
 }
 
 func (db *MockDataStore) Transcoding(ctx context.Context) model.TranscodingRepository {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -155,7 +155,12 @@
         "currentPassword": "Current Password",
         "newPassword": "New Password",
         "token": "Token",
-        "libraries": "Libraries"
+        "libraries": "Libraries",
+        "appPasswords": "App Passwords",
+        "appPasswordName": "Name",
+        "appPasswordCreatedAt": "Created",
+        "appPasswordLastUsedAt": "Last Used",
+        "appPasswordStatus": "Status"
       },
       "helperTexts": {
         "name": "Changes to your name will only be reflected on next login",
@@ -164,7 +169,17 @@
       "notifications": {
         "created": "User created",
         "updated": "User updated",
-        "deleted": "User deleted"
+        "deleted": "User deleted",
+        "appPasswordRevoked": "App password revoked",
+        "appPasswordRevokeError": "Could not revoke app password",
+        "appPasswordCreateError": "Could not create app password",
+        "appPasswordLoadError": "Could not load app passwords",
+        "appPasswordCopied": "Copied to clipboard"
+      },
+      "actions": {
+        "generateAppPassword": "Generate App Password",
+        "revokeAppPassword": "Revoke",
+        "copyAppPassword": "Copy"
       },
       "validation": {
         "librariesRequired": "At least one library must be selected for non-admin users"
@@ -173,7 +188,13 @@
         "listenBrainzToken": "Enter your ListenBrainz user token.",
         "clickHereForToken": "Click here to get your token",
         "selectAllLibraries": "Select all libraries",
-        "adminAutoLibraries": "Admin users automatically have access to all libraries"
+        "adminAutoLibraries": "Admin users automatically have access to all libraries",
+        "appPasswordsEmpty": "No app passwords yet. Generate one to use with Subsonic-compatible clients.",
+        "appPasswordCreatePrompt": "Give this app password a name so you remember which device or app it's for.",
+        "appPasswordCreated": "App password created",
+        "appPasswordOneTime": "Save this secret now — it will not be shown again. Paste it into your Subsonic client in place of your account password.",
+        "appPasswordActive": "Active",
+        "appPasswordRevoked": "Revoked"
       }
     },
     "player": {

--- a/ui/src/user/AppPasswordPanel.jsx
+++ b/ui/src/user/AppPasswordPanel.jsx
@@ -1,0 +1,284 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline'
+import FileCopyIcon from '@material-ui/icons/FileCopy'
+import { useNotify, useTranslate } from 'react-admin'
+import { makeStyles } from '@material-ui/core/styles'
+import httpClient from '../dataProvider/httpClient'
+import { REST_URL } from '../consts'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: '100%',
+    marginTop: theme.spacing(3),
+    padding: theme.spacing(2),
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(1),
+  },
+  empty: {
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+    padding: theme.spacing(2, 0),
+  },
+  secretField: {
+    fontFamily: 'monospace',
+    width: '100%',
+  },
+  secretActions: {
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: theme.spacing(1),
+  },
+}))
+
+// AppPasswordPanel renders a list of the user's app passwords with a button to
+// generate a new one and a per-row revoke button. The plaintext secret is
+// shown exactly once, in a modal, immediately after generation. After the
+// modal is dismissed the secret is unrecoverable from the UI.
+export const AppPasswordPanel = ({ userId }) => {
+  const classes = useStyles()
+  const translate = useTranslate()
+  const notify = useNotify()
+
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [generated, setGenerated] = useState(null)
+
+  const reload = useCallback(async () => {
+    if (!userId) return
+    setLoading(true)
+    try {
+      const { json } = await httpClient(
+        `${REST_URL}/user/${userId}/app-password`,
+      )
+      setItems(Array.isArray(json) ? json : [])
+    } catch (e) {
+      notify('resources.user.notifications.appPasswordLoadError', 'warning')
+    } finally {
+      setLoading(false)
+    }
+  }, [userId, notify])
+
+  useEffect(() => {
+    reload()
+  }, [reload])
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      const { json } = await httpClient(
+        `${REST_URL}/user/${userId}/app-password`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ name: newName.trim() }),
+        },
+      )
+      setGenerated(json)
+      setCreateOpen(false)
+      setNewName('')
+      await reload()
+    } catch (e) {
+      const msg =
+        e?.body?.toString?.() ||
+        e?.message ||
+        translate('resources.user.notifications.appPasswordCreateError')
+      notify(msg, 'warning')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleRevoke = async (id) => {
+    try {
+      await httpClient(`${REST_URL}/user/${userId}/app-password/${id}`, {
+        method: 'DELETE',
+      })
+      notify('resources.user.notifications.appPasswordRevoked', 'info')
+      await reload()
+    } catch (e) {
+      notify('resources.user.notifications.appPasswordRevokeError', 'warning')
+    }
+  }
+
+  const handleCopy = (value) => {
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(value)
+      notify('resources.user.notifications.appPasswordCopied', 'info')
+    }
+  }
+
+  const formatDate = (d) => (d ? new Date(d).toLocaleString() : '—')
+
+  return (
+    <Paper className={classes.root} elevation={0} variant="outlined">
+      <Box className={classes.header}>
+        <Typography variant="h6">
+          {translate('resources.user.fields.appPasswords')}
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => setCreateOpen(true)}
+        >
+          {translate('resources.user.actions.generateAppPassword')}
+        </Button>
+      </Box>
+
+      {!loading && items.length === 0 && (
+        <Typography className={classes.empty}>
+          {translate('resources.user.message.appPasswordsEmpty')}
+        </Typography>
+      )}
+
+      {items.length > 0 && (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                {translate('resources.user.fields.appPasswordName')}
+              </TableCell>
+              <TableCell>
+                {translate('resources.user.fields.appPasswordCreatedAt')}
+              </TableCell>
+              <TableCell>
+                {translate('resources.user.fields.appPasswordLastUsedAt')}
+              </TableCell>
+              <TableCell>
+                {translate('resources.user.fields.appPasswordStatus')}
+              </TableCell>
+              <TableCell align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.name}</TableCell>
+                <TableCell>{formatDate(row.createdAt)}</TableCell>
+                <TableCell>{formatDate(row.lastUsedAt)}</TableCell>
+                <TableCell>
+                  {row.revokedAt
+                    ? translate('resources.user.message.appPasswordRevoked')
+                    : translate('resources.user.message.appPasswordActive')}
+                </TableCell>
+                <TableCell align="right">
+                  {!row.revokedAt && (
+                    <Tooltip
+                      title={translate(
+                        'resources.user.actions.revokeAppPassword',
+                      )}
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRevoke(row.id)}
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog
+        open={createOpen}
+        onClose={() => !creating && setCreateOpen(false)}
+      >
+        <DialogTitle>
+          {translate('resources.user.actions.generateAppPassword')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {translate('resources.user.message.appPasswordCreatePrompt')}
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            margin="dense"
+            label={translate('resources.user.fields.appPasswordName')}
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            disabled={creating}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)} disabled={creating}>
+            {translate('ra.action.cancel')}
+          </Button>
+          <Button
+            onClick={handleCreate}
+            color="primary"
+            disabled={creating || !newName.trim()}
+          >
+            {translate('ra.action.create')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={!!generated} onClose={() => setGenerated(null)} fullWidth>
+        <DialogTitle>
+          {translate('resources.user.message.appPasswordCreated')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {translate('resources.user.message.appPasswordOneTime')}
+          </DialogContentText>
+          {generated && (
+            <>
+              <TextField
+                value={generated.secret}
+                className={classes.secretField}
+                InputProps={{ readOnly: true }}
+                onFocus={(e) => e.target.select()}
+                multiline
+              />
+              <Box className={classes.secretActions}>
+                <Button
+                  startIcon={<FileCopyIcon />}
+                  onClick={() => handleCopy(generated.secret)}
+                >
+                  {translate('resources.user.actions.copyAppPassword')}
+                </Button>
+              </Box>
+            </>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setGenerated(null)} color="primary">
+            {translate('ra.action.close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  )
+}
+
+export default AppPasswordPanel

--- a/ui/src/user/AppPasswordPanel.test.jsx
+++ b/ui/src/user/AppPasswordPanel.test.jsx
@@ -1,0 +1,211 @@
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const httpClient = vi.fn()
+vi.mock('../dataProvider/httpClient', () => ({
+  default: (...args) => httpClient(...args),
+}))
+
+const notify = vi.fn()
+const translate = (key) => key
+vi.mock('react-admin', () => ({
+  useTranslate: () => translate,
+  useNotify: () => notify,
+}))
+
+vi.mock('@material-ui/core/styles', () => ({
+  makeStyles: () => () => ({
+    root: '',
+    header: '',
+    empty: '',
+    secretField: '',
+    secretActions: '',
+  }),
+}))
+
+vi.mock('@material-ui/core', () => {
+  const passthrough = (tag, testIdProp) =>
+    React.forwardRef(({ children, ...props }, ref) => {
+      const { ...rest } = props
+      const testId = testIdProp ? rest[testIdProp] : undefined
+      const cleaned = { ...rest }
+      delete cleaned.classes
+      delete cleaned.elevation
+      delete cleaned.variant
+      delete cleaned.size
+      delete cleaned.fullWidth
+      delete cleaned.startIcon
+      delete cleaned.color
+      delete cleaned.align
+      delete cleaned.margin
+      delete cleaned.InputProps
+      delete cleaned.multiline
+      return React.createElement(
+        tag,
+        { ref, ...cleaned, 'data-testid': testId },
+        children,
+      )
+    })
+
+  const Button = React.forwardRef(({ children, onClick, disabled }, ref) =>
+    React.createElement(
+      'button',
+      {
+        ref,
+        onClick,
+        disabled,
+        'data-testid': 'btn-' + String(children).replace(/\s/g, '-'),
+      },
+      children,
+    ),
+  )
+  const TextField = React.forwardRef(
+    ({ value, onChange, onFocus, label }, ref) =>
+      React.createElement('input', {
+        ref,
+        value: value ?? '',
+        onChange,
+        onFocus,
+        'data-testid': 'tf-' + (label || 'unlabeled'),
+        readOnly: false,
+      }),
+  )
+  return {
+    Box: passthrough('div'),
+    Paper: passthrough('div'),
+    Table: passthrough('table'),
+    TableBody: passthrough('tbody'),
+    TableCell: passthrough('td'),
+    TableHead: passthrough('thead'),
+    TableRow: passthrough('tr'),
+    Typography: passthrough('div'),
+    Tooltip: ({ children }) => children,
+    IconButton: ({ onClick, children }) =>
+      React.createElement(
+        'button',
+        { onClick, 'data-testid': 'icon-button' },
+        children,
+      ),
+    Dialog: ({ open, children }) =>
+      open
+        ? React.createElement('div', { 'data-testid': 'dialog' }, children)
+        : null,
+    DialogTitle: passthrough('h2'),
+    DialogContent: passthrough('div'),
+    DialogContentText: passthrough('p'),
+    DialogActions: passthrough('div'),
+    Button,
+    TextField,
+  }
+})
+
+vi.mock('@material-ui/icons/DeleteOutline', () => ({
+  default: () => React.createElement('span', null, 'del'),
+}))
+vi.mock('@material-ui/icons/FileCopy', () => ({
+  default: () => React.createElement('span', null, 'cp'),
+}))
+
+vi.mock('../consts', () => ({
+  REST_URL: '/api',
+}))
+
+import { AppPasswordPanel } from './AppPasswordPanel.jsx'
+
+describe('<AppPasswordPanel />', () => {
+  beforeEach(() => {
+    httpClient.mockReset()
+  })
+
+  it('renders the empty-state copy when the API returns no items', async () => {
+    httpClient.mockResolvedValueOnce({ json: [] })
+
+    render(<AppPasswordPanel userId="user-1" />)
+
+    await waitFor(() => {
+      expect(httpClient).toHaveBeenCalledWith('/api/user/user-1/app-password')
+    })
+    expect(
+      screen.getByText('resources.user.message.appPasswordsEmpty'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders rows for each item returned by the API', async () => {
+    httpClient.mockResolvedValueOnce({
+      json: [
+        {
+          id: 'ap1',
+          name: 'iPhone Tempus',
+          createdAt: '2026-04-27T00:00:00Z',
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ],
+    })
+
+    render(<AppPasswordPanel userId="user-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('iPhone Tempus')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('resources.user.message.appPasswordActive'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the generated secret in a one-time dialog after creation', async () => {
+    httpClient
+      .mockResolvedValueOnce({ json: [] }) // initial load
+      .mockResolvedValueOnce({
+        json: { id: 'ap1', name: 'X', secret: 'super-secret-123' },
+      }) // POST
+      .mockResolvedValueOnce({ json: [] }) // reload after create
+
+    render(<AppPasswordPanel userId="user-1" />)
+    await waitFor(() => expect(httpClient).toHaveBeenCalledTimes(1))
+
+    // open create dialog
+    fireEvent.click(
+      screen.getByTestId('btn-resources.user.actions.generateAppPassword'),
+    )
+    const nameInput = screen.getByTestId(
+      'tf-resources.user.fields.appPasswordName',
+    )
+    fireEvent.change(nameInput, { target: { value: 'Phone' } })
+    fireEvent.click(screen.getByTestId('btn-ra.action.create'))
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('super-secret-123')).toBeInTheDocument()
+    })
+  })
+
+  it('calls the revoke endpoint when the per-row revoke button is clicked', async () => {
+    httpClient
+      .mockResolvedValueOnce({
+        json: [
+          {
+            id: 'ap1',
+            name: 'iPhone',
+            createdAt: '2026-04-27T00:00:00Z',
+            lastUsedAt: null,
+            revokedAt: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ json: { id: 'ap1' } })
+      .mockResolvedValueOnce({ json: [] })
+
+    render(<AppPasswordPanel userId="user-1" />)
+    await waitFor(() => expect(screen.getByText('iPhone')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('icon-button'))
+
+    await waitFor(() => {
+      expect(httpClient).toHaveBeenCalledWith(
+        '/api/user/user-1/app-password/ap1',
+        { method: 'DELETE' },
+      )
+    })
+  })
+})

--- a/ui/src/user/AppPasswordPanel.test.jsx
+++ b/ui/src/user/AppPasswordPanel.test.jsx
@@ -25,11 +25,10 @@ vi.mock('@material-ui/core/styles', () => ({
 }))
 
 vi.mock('@material-ui/core', () => {
-  const passthrough = (tag, testIdProp) =>
-    React.forwardRef(({ children, ...props }, ref) => {
-      const { ...rest } = props
-      const testId = testIdProp ? rest[testIdProp] : undefined
-      const cleaned = { ...rest }
+  const passthrough = (tag, displayName) => {
+    const Component = React.forwardRef(({ children, ...props }, ref) => {
+      const cleaned = { ...props }
+      // Strip Material-UI-only props that don't belong on plain DOM nodes.
       delete cleaned.classes
       delete cleaned.elevation
       delete cleaned.variant
@@ -41,12 +40,11 @@ vi.mock('@material-ui/core', () => {
       delete cleaned.margin
       delete cleaned.InputProps
       delete cleaned.multiline
-      return React.createElement(
-        tag,
-        { ref, ...cleaned, 'data-testid': testId },
-        children,
-      )
+      return React.createElement(tag, { ref, ...cleaned }, children)
     })
+    Component.displayName = displayName
+    return Component
+  }
 
   const Button = React.forwardRef(({ children, onClick, disabled }, ref) =>
     React.createElement(
@@ -60,6 +58,8 @@ vi.mock('@material-ui/core', () => {
       children,
     ),
   )
+  Button.displayName = 'MockButton'
+
   const TextField = React.forwardRef(
     ({ value, onChange, onFocus, label }, ref) =>
       React.createElement('input', {
@@ -71,41 +71,56 @@ vi.mock('@material-ui/core', () => {
         readOnly: false,
       }),
   )
+  TextField.displayName = 'MockTextField'
+
+  const Tooltip = ({ children }) => children
+  Tooltip.displayName = 'MockTooltip'
+
+  const IconButton = ({ onClick, children }) =>
+    React.createElement(
+      'button',
+      { onClick, 'data-testid': 'icon-button' },
+      children,
+    )
+  IconButton.displayName = 'MockIconButton'
+
+  const Dialog = ({ open, children }) =>
+    open
+      ? React.createElement('div', { 'data-testid': 'dialog' }, children)
+      : null
+  Dialog.displayName = 'MockDialog'
+
   return {
-    Box: passthrough('div'),
-    Paper: passthrough('div'),
-    Table: passthrough('table'),
-    TableBody: passthrough('tbody'),
-    TableCell: passthrough('td'),
-    TableHead: passthrough('thead'),
-    TableRow: passthrough('tr'),
-    Typography: passthrough('div'),
-    Tooltip: ({ children }) => children,
-    IconButton: ({ onClick, children }) =>
-      React.createElement(
-        'button',
-        { onClick, 'data-testid': 'icon-button' },
-        children,
-      ),
-    Dialog: ({ open, children }) =>
-      open
-        ? React.createElement('div', { 'data-testid': 'dialog' }, children)
-        : null,
-    DialogTitle: passthrough('h2'),
-    DialogContent: passthrough('div'),
-    DialogContentText: passthrough('p'),
-    DialogActions: passthrough('div'),
+    Box: passthrough('div', 'MockBox'),
+    Paper: passthrough('div', 'MockPaper'),
+    Table: passthrough('table', 'MockTable'),
+    TableBody: passthrough('tbody', 'MockTableBody'),
+    TableCell: passthrough('td', 'MockTableCell'),
+    TableHead: passthrough('thead', 'MockTableHead'),
+    TableRow: passthrough('tr', 'MockTableRow'),
+    Typography: passthrough('div', 'MockTypography'),
+    Tooltip,
+    IconButton,
+    Dialog,
+    DialogTitle: passthrough('h2', 'MockDialogTitle'),
+    DialogContent: passthrough('div', 'MockDialogContent'),
+    DialogContentText: passthrough('p', 'MockDialogContentText'),
+    DialogActions: passthrough('div', 'MockDialogActions'),
     Button,
     TextField,
   }
 })
 
-vi.mock('@material-ui/icons/DeleteOutline', () => ({
-  default: () => React.createElement('span', null, 'del'),
-}))
-vi.mock('@material-ui/icons/FileCopy', () => ({
-  default: () => React.createElement('span', null, 'cp'),
-}))
+vi.mock('@material-ui/icons/DeleteOutline', () => {
+  const MockDeleteOutlineIcon = () => React.createElement('span', null, 'del')
+  MockDeleteOutlineIcon.displayName = 'MockDeleteOutlineIcon'
+  return { default: MockDeleteOutlineIcon }
+})
+vi.mock('@material-ui/icons/FileCopy', () => {
+  const MockFileCopyIcon = () => React.createElement('span', null, 'cp')
+  MockFileCopyIcon.displayName = 'MockFileCopyIcon'
+  return { default: MockFileCopyIcon }
+})
 
 vi.mock('../consts', () => ({
   REST_URL: '/api',

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -24,6 +24,7 @@ import { Typography } from '@material-ui/core'
 import { Title } from '../common'
 import DeleteUserButton from './DeleteUserButton'
 import { LibrarySelectionField } from './LibrarySelectionField.jsx'
+import { AppPasswordPanel } from './AppPasswordPanel.jsx'
 import { validateUserForm } from './userValidation'
 
 const useStyles = makeStyles({
@@ -175,6 +176,8 @@ const UserEdit = (props) => {
         <DateField variant="body1" source="lastAccessAt" showTime />
         <DateField variant="body1" source="updatedAt" showTime />
         <DateField variant="body1" source="createdAt" showTime />
+
+        <AppPasswordPanel userId={props.id} />
       </SimpleForm>
     </Edit>
   )

--- a/ui/src/user/UserEdit.test.jsx
+++ b/ui/src/user/UserEdit.test.jsx
@@ -66,6 +66,10 @@ vi.mock('./LibrarySelectionField.jsx', () => ({
   LibrarySelectionField: () => <div data-testid="library-selection-field" />,
 }))
 
+vi.mock('./AppPasswordPanel.jsx', () => ({
+  AppPasswordPanel: () => <div data-testid="app-password-panel" />,
+}))
+
 vi.mock('./DeleteUserButton', () => ({
   __esModule: true,
   default: () => <button data-testid="delete-user-button">Delete</button>,


### PR DESCRIPTION
## Summary

Adds revocable, per-device credentials that authenticate Subsonic clients independently of a user's main password. Closes the password-reuse hole called out by `helmut72`/`nroach44` in [navidrome#141](https://github.com/navidrome/navidrome/issues/141): when an LDAP-backed user pastes their directory password into Tempus/Feishin/etc., that password ends up reversibly-encrypted in Navidrome's DB (since Subsonic salt+token auth needs the plaintext server-side). With this PR, clients can use a per-device secret instead.

Closes #6.

## What's in the PR

### Schema + persistence
- New `user_app_password` table (goose Go migration) — `id, user_id, name, password, created_at, last_used_at, revoked_at`. CASCADE on user delete; UNIQUE `(user_id, name)`.
- `model.AppPasswordRepository`: `Put / Get / List / FindActiveByUser / Revoke / RevokeAllForUser / Touch`.
- `Get` and `List` always scrub the encrypted blob from the response. `FindActiveByUser` is the **only** code path that decrypts, and it's reserved for the auth fallback.
- Reuses the existing `userRepository` AES-256-GCM encryption key — no new crypto config to manage.

### Subsonic auth integration (`server/subsonic/middlewares.go`)
- After the regular password / salt+token / JWT check, fall back to matching against the user's active app passwords.
- Bumps `last_used_at` on success (best-effort, errors are logged not surfaced).
- JWT and internal/reverse-proxy auth paths are untouched.

### Native API (`/api/user/{id}/app-password`)
| Method | Path | Purpose |
|---|---|---|
| `GET`  | `/user/{id}/app-password` | list (metadata only, never the secret) |
| `POST` | `/user/{id}/app-password` | create — **returns plaintext secret exactly once** |
| `DELETE` | `/user/{id}/app-password/{appId}` | revoke single |
| `DELETE` | `/user/{id}/app-password` | revoke all for the user |

Per-handler middleware enforces owner-or-admin authorization. The per-row revoke also checks that the app password belongs to the user from the URL path — so an admin can't accidentally revoke `userB`'s password by hitting `/user/userA/app-password/{userB-app-pw-id}`.

### UI (`ui/src/user/AppPasswordPanel.jsx`)
Mounted in `UserEdit`. Lists name / created / last-used / status with a per-row revoke. "Generate" prompts for a name, then displays the plaintext secret in a one-time modal with copy.

### Translations
New keys under `resources.user.{fields,actions,notifications,message}.appPassword*` in `ui/src/i18n/en.json`.

## What this PR does NOT do (intentionally)

- **Does not stop persisting the LDAP password** in `server/auth.go:236`. That's the next issue (#7) and depends on app passwords existing as the migration target.
- **Does not reject the LDAP password at `/rest`**. Same reason — kept for back-compat in this PR. App passwords are an *additional* accepted credential, not a replacement yet.
- **Does not restrict app-password creation to LDAP users only**. Local users benefit from per-device revocation too, and the LDAP/local user-type flag the README mentions as a TODO doesn't exist yet.

## Tests

| Layer | Coverage |
|---|---|
| Persistence (`persistence/app_password_repository_test.go`) | Encryption round-trip, list-vs-find-active scrubbing, revoke / revoke-all / touch, duplicate-name rejection, FK isolation between users, double-revoke returns `ErrNotFound`. |
| Subsonic auth (`server/subsonic/app_password_auth_test.go`) | Legacy `p=` and salt+token paths both accept main password and app password as fallback; revoked passwords are rejected; users without app passwords are unaffected; `last_used_at` is bumped on success. |
| Native API (`server/nativeapi/app_password_test.go`) | Owner can manage own, admin can manage any, non-owner non-admin gets 403, mismatched `/user/{id}/app-password/{otherId}` gets 404, secret never appears in list responses. |
| UI (`ui/src/user/AppPasswordPanel.test.jsx`) | Empty-state, list rendering, one-time secret dialog, revoke flow. |

All affected Go packages pass; all 490 UI tests still pass; `golangci-lint` clean.

## Test plan

- [ ] Apply migration on a fresh DB; confirm `user_app_password` table exists.
- [ ] As a regular user, generate an app password from the user-edit page; confirm the secret is shown once and not present in subsequent list calls.
- [ ] Authenticate against `/rest/ping` using `u=alice&p=<app-password-secret>` — confirm OK.
- [ ] Same with salt+token: `u=alice&t=md5(secret+salt)&s=salt` — confirm OK.
- [ ] Revoke and confirm the next request with that secret returns 401.
- [ ] Confirm the user's main password still works.
- [ ] As a non-admin user, try `GET /api/user/<other-user>/app-password` — confirm 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)