### PR TITLE
feat: periodic LDAP liveness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,17 @@ If you ran an earlier version of `navidrome-ldap` that persisted the directory p
 - After migration, Subsonic clients must use an app password. Each user can generate one from their user-edit page (Settings → App Passwords).
 - The migration is one-way per user. Operators who want to flush all persisted passwords up front can have each user log in once, or run a database command to mark all users as LDAP and clear passwords manually.
 
+### Liveness check
+
+When `ND_LDAP_LIVENESSSCHEDULE` is set, Navidrome runs a recurring sweep that reconciles every LDAP-backed user against the directory. If a user has been removed from the directory (or matches the optional `ND_LDAP_DISABLEDFILTER` clause), the sweep revokes all of that user's app passwords. Combined with PR #11's empty stored password, this is the lockout mechanism for LDAP-managed accounts: revoking the app passwords removes the only credential they had for the Subsonic API, and they can no longer log in to the web UI either (LDAP rejects them, and there is no local password to fall back on).
+
+The sweep is fail-safe: if the directory is unreachable or the service-account bind fails, the run is aborted without revoking anything. Per-user search errors log a warning and skip just that user.
+
+The interval is the lockout window operators are accepting — pick something that matches the urgency of your offboarding policy. The default is disabled (no sweep).
+
 ### TODO
 
 - [ ] Add the ability to auto-assign admins using an LDAP group
-- [ ] Periodic LDAP liveness check to revoke disabled accounts
 
 ### Docker Container
 
@@ -108,6 +115,8 @@ You can configure LDAP using the following environment variables:
 | `ND_LDAP_SEARCHFILTER` | The filter to search for users. `%s` is replaced by the username | `(uid=%s)` |
 | `ND_LDAP_NAME` | The LDAP attribute to map to the user's full name | `cn` |
 | `ND_LDAP_MAIL` | The LDAP attribute to map to the user's email | `mail` |
+| `ND_LDAP_LIVENESSSCHEDULE` | How often the liveness sweep runs. Accepts a duration (`5m`, `1h`) or a full crontab. Empty disables the sweep. | `15m` |
+| `ND_LDAP_DISABLEDFILTER` | Optional LDAP filter ANDed with `SearchFilter` to flag disabled entries. The filter applies to the user's own attributes — it does not take a `%s`. | `(loginShell=/sbin/nologin)` |
 
 ## Translations
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/navidrome/navidrome/resources"
 	"github.com/navidrome/navidrome/scanner"
 	"github.com/navidrome/navidrome/scheduler"
+	"github.com/navidrome/navidrome/server"
 	"github.com/navidrome/navidrome/server/backgrounds"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -87,6 +88,7 @@ func runNavidrome(ctx context.Context) {
 	g.Go(schedulePeriodicBackup(ctx))
 	g.Go(startInsightsCollector(ctx))
 	g.Go(scheduleDBOptimizer(ctx))
+	g.Go(scheduleLDAPLivenessCheck(ctx))
 	g.Go(startPluginManager(ctx))
 	g.Go(runInitialScan(ctx))
 	if conf.Server.Scanner.Enabled {
@@ -286,6 +288,31 @@ func scheduleDBOptimizer(ctx context.Context) func() error {
 			}
 			db.Optimize(ctx)
 		})
+		return err
+	}
+}
+
+// scheduleLDAPLivenessCheck schedules a recurring sweep that revokes
+// the app passwords of LDAP-backed users who are no longer present (or
+// are flagged disabled) in the configured directory.
+func scheduleLDAPLivenessCheck(ctx context.Context) func() error {
+	return func() error {
+		schedule := conf.Server.LDAP.LivenessSchedule
+		if schedule == "" || conf.Server.LDAP.Host == "" {
+			log.Info(ctx, "LDAP liveness check is DISABLED")
+			return nil
+		}
+
+		ds := CreateDataStore()
+		schedulerInstance := scheduler.GetInstance()
+
+		log.Info("Scheduling LDAP liveness check", "schedule", schedule)
+		_, err := schedulerInstance.Add(schedule, func() {
+			server.LDAPLivenessCheck(ctx, ds)
+		})
+		if err != nil {
+			log.Error(ctx, "Error scheduling LDAP liveness check", err)
+		}
 		return err
 	}
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -180,6 +180,21 @@ type ldapOptions struct {
 	SearchFilter string
 	Mail         string
 	Name         string
+
+	// LivenessSchedule, when non-empty, schedules a background sweep that
+	// reconciles each LDAP-backed user against the directory and revokes
+	// the app passwords of users that no longer match. Accepts any
+	// scheduler spec (a duration like "5m" or a full crontab). Empty
+	// disables the sweep.
+	LivenessSchedule string
+	// DisabledFilter is an optional LDAP filter clause that, when ANDed
+	// with the per-user SearchFilter, identifies disabled directory
+	// entries (e.g. AD's `(userAccountControl:1.2.840.113556.1.4.803:=2)`
+	// or a custom `(loginShell=/sbin/nologin)`). When set, an entry that
+	// still exists but matches this filter is treated the same as one
+	// that has been removed. The filter applies to the user's own
+	// attributes — it is NOT formatted with the username.
+	DisabledFilter string
 }
 
 type TagConf struct {
@@ -389,6 +404,7 @@ func Load(noConfigDump bool) {
 	err = run.Sequentially(
 		validateScanSchedule,
 		validateBackupSchedule,
+		validateLDAPLivenessSchedule,
 		validatePlaylistsPath,
 		validatePurgeMissingOption,
 		validateMaxImageUploadSize,
@@ -641,6 +657,16 @@ func validateScanSchedule() error {
 	}
 	var err error
 	Server.Scanner.Schedule, err = validateSchedule(Server.Scanner.Schedule, "Scanner.Schedule")
+	return err
+}
+
+func validateLDAPLivenessSchedule() error {
+	if Server.LDAP.LivenessSchedule == "0" || Server.LDAP.LivenessSchedule == "" {
+		Server.LDAP.LivenessSchedule = ""
+		return nil
+	}
+	var err error
+	Server.LDAP.LivenessSchedule, err = validateSchedule(Server.LDAP.LivenessSchedule, "LDAP.LivenessSchedule")
 	return err
 }
 

--- a/server/ldap_liveness.go
+++ b/server/ldap_liveness.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/go-ldap/ldap"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+// livenessProbe answers "is this LDAP user still active in the
+// directory?" for a given username. The reason describes which negative
+// case applied: "missing" if the directory has no entry for the user,
+// "disabled" if the entry exists but matched DisabledFilter. err
+// indicates a transient failure — callers must NOT treat this as a
+// signal to revoke.
+type livenessProbe func(userName string) (active bool, reason string, err error)
+
+// LDAPLivenessCheck reconciles every LDAP-backed user against the
+// configured directory and revokes the app passwords of users that no
+// longer match — either because they were removed from the directory or
+// because they match the configured DisabledFilter. LDAP-backed users
+// have an empty stored password (PR #11), so revoking app passwords is
+// the last credential they had — once their app passwords are gone they
+// cannot authenticate via /rest, and web login fails because they are
+// no longer in the directory.
+//
+// On any directory-wide failure (dial, service-account bind), the run
+// is aborted without revoking anything; the next scheduled tick will
+// retry. Per-user search errors log a warning and skip just that user.
+func LDAPLivenessCheck(ctx context.Context, ds model.DataStore) {
+	if conf.Server.LDAP.Host == "" {
+		return
+	}
+
+	l, err := ldap.DialURL(conf.Server.LDAP.Host)
+	if err != nil {
+		log.Warn(ctx, "LDAP liveness: dial failed; skipping run", "host", conf.Server.LDAP.Host, err)
+		return
+	}
+	defer l.Close()
+
+	if err := l.Bind(conf.Server.LDAP.BindDN, conf.Server.LDAP.BindPassword); err != nil {
+		log.Warn(ctx, "LDAP liveness: service-account bind failed; skipping run", "bindDN", conf.Server.LDAP.BindDN, err)
+		return
+	}
+
+	runLDAPLivenessCheck(ctx, ds, ldapProbe(l))
+}
+
+// runLDAPLivenessCheck is the testable core: given a probe, walk every
+// LDAP-backed user and revoke app passwords for ones that don't pass.
+func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenessProbe) {
+	userRepo := ds.User(ctx)
+	users, err := userRepo.GetAll(model.QueryOptions{
+		Filters: squirrel.Eq{"auth_type": model.AuthTypeLDAP},
+	})
+	if err != nil {
+		log.Error(ctx, "LDAP liveness: failed to load LDAP users", err)
+		return
+	}
+	if len(users) == 0 {
+		return
+	}
+
+	appRepo := ds.AppPassword(ctx)
+	checked := 0
+	revoked := 0
+	for _, u := range users {
+		// Defense-in-depth: the SQL filter above should have done this,
+		// but never revoke a local user's app passwords just because a
+		// future caller forgot to scope the query.
+		if !u.IsLDAP() {
+			continue
+		}
+		active, reason, err := probe(u.UserName)
+		if err != nil {
+			log.Warn(ctx, "LDAP liveness: probe failed; skipping user", "user", u.UserName, err)
+			continue
+		}
+		checked++
+		if active {
+			continue
+		}
+
+		n, err := appRepo.RevokeAllForUser(u.ID)
+		if err != nil {
+			log.Error(ctx, "LDAP liveness: failed to revoke app passwords", "user", u.UserName, err)
+			continue
+		}
+		revoked++
+		log.Info(ctx, "LDAP liveness: revoked app passwords for user no longer authorized",
+			"user", u.UserName, "reason", reason, "appPasswords", n)
+	}
+	log.Debug(ctx, "LDAP liveness: run complete", "users", len(users), "checked", checked, "revoked", revoked)
+}
+
+// ldapProbe builds a livenessProbe that consults the given LDAP
+// connection. The connection must already be bound as the service
+// account.
+func ldapProbe(l *ldap.Conn) livenessProbe {
+	return func(userName string) (active bool, reason string, err error) {
+		base := conf.Server.LDAP.Base
+		userFilter := fmt.Sprintf(conf.Server.LDAP.SearchFilter, ldap.EscapeFilter(userName))
+
+		// Does the user exist in the directory at all?
+		sr, err := l.Search(ldap.NewSearchRequest(
+			base, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			userFilter, []string{"dn"}, nil,
+		))
+		if err != nil {
+			return false, "", err
+		}
+		if len(sr.Entries) == 0 {
+			return false, "missing", nil
+		}
+
+		// User exists. If DisabledFilter is set, check whether they match it.
+		// Don't penalize the user for a transient search error here:
+		// assume active and reconcile on the next tick rather than
+		// revoking based on a flaky directory response.
+		if df := conf.Server.LDAP.DisabledFilter; df != "" {
+			disabledFilter := "(&" + userFilter + df + ")"
+			sr2, searchErr := l.Search(ldap.NewSearchRequest(
+				base, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+				disabledFilter, []string{"dn"}, nil,
+			))
+			if searchErr == nil && len(sr2.Entries) > 0 {
+				return false, "disabled", nil
+			}
+		}
+
+		return true, "", nil
+	}
+}

--- a/server/ldap_liveness_test.go
+++ b/server/ldap_liveness_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"context"
+	"errors"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LDAP liveness check", func() {
+	var (
+		ds       *tests.MockDataStore
+		users    model.UserRepository
+		appPwds  model.AppPasswordRepository
+		original string
+	)
+
+	BeforeEach(func() {
+		ds = &tests.MockDataStore{}
+		users = ds.User(context.Background())
+		appPwds = ds.AppPassword(context.Background())
+		original = conf.Server.LDAP.Host
+	})
+
+	AfterEach(func() {
+		conf.Server.LDAP.Host = original
+	})
+
+	// Helper: seed one LDAP user with one active app password.
+	seedLDAPUser := func(id, username string) {
+		Expect(users.Put(&model.User{
+			ID:       id,
+			UserName: username,
+			AuthType: model.AuthTypeLDAP,
+		})).To(Succeed())
+		Expect(users.ClearPassword(id)).To(Succeed())
+		Expect(appPwds.Put(&model.AppPassword{
+			UserID:      id,
+			Name:        "iPhone",
+			NewPassword: "secret-" + id,
+		})).To(Succeed())
+	}
+
+	// Helper: count active app passwords for a given user.
+	activeCount := func(userID string) int {
+		active, err := appPwds.FindActiveByUser(userID)
+		Expect(err).ToNot(HaveOccurred())
+		return len(active)
+	}
+
+	Context("LDAPLivenessCheck top-level", func() {
+		It("is a no-op when LDAP.Host is not configured", func() {
+			conf.Server.LDAP.Host = ""
+			seedLDAPUser("u1", "alice")
+
+			LDAPLivenessCheck(context.Background(), ds)
+
+			Expect(activeCount("u1")).To(Equal(1))
+		})
+
+		It("aborts the run on dial failure without revoking anything", func() {
+			conf.Server.LDAP.Host = "ldap://invalid-host-that-does-not-resolve:389"
+			seedLDAPUser("u1", "alice")
+
+			LDAPLivenessCheck(context.Background(), ds)
+
+			Expect(activeCount("u1")).To(Equal(1))
+		})
+	})
+
+	Context("runLDAPLivenessCheck core loop", func() {
+		It("revokes app passwords for users the directory reports missing", func() {
+			seedLDAPUser("u-missing", "ghost")
+			seedLDAPUser("u-active", "alive")
+
+			probe := func(name string) (bool, string, error) {
+				if name == "ghost" {
+					return false, "missing", nil
+				}
+				return true, "", nil
+			}
+			runLDAPLivenessCheck(context.Background(), ds, probe)
+
+			Expect(activeCount("u-missing")).To(Equal(0))
+			Expect(activeCount("u-active")).To(Equal(1))
+		})
+
+		It("revokes app passwords for users matched by DisabledFilter", func() {
+			seedLDAPUser("u-disabled", "fired")
+
+			probe := func(name string) (bool, string, error) {
+				return false, "disabled", nil
+			}
+			runLDAPLivenessCheck(context.Background(), ds, probe)
+
+			Expect(activeCount("u-disabled")).To(Equal(0))
+		})
+
+		It("does not revoke when the probe returns a transient error", func() {
+			seedLDAPUser("u-flaky", "flaky")
+
+			probe := func(name string) (bool, string, error) {
+				return false, "", errors.New("transient ldap search failure")
+			}
+			runLDAPLivenessCheck(context.Background(), ds, probe)
+
+			Expect(activeCount("u-flaky")).To(Equal(1))
+		})
+
+		It("ignores non-LDAP users even if they slip through GetAll", func() {
+			Expect(users.Put(&model.User{
+				ID:          "u-local",
+				UserName:    "localuser",
+				NewPassword: "local-secret",
+			})).To(Succeed())
+			Expect(appPwds.Put(&model.AppPassword{
+				UserID:      "u-local",
+				Name:        "iPad",
+				NewPassword: "local-app",
+			})).To(Succeed())
+
+			// Probe says "missing" for everyone — should still spare the local user.
+			probe := func(name string) (bool, string, error) {
+				return false, "missing", nil
+			}
+			runLDAPLivenessCheck(context.Background(), ds, probe)
+
+			Expect(activeCount("u-local")).To(Equal(1))
+		})
+
+		It("is a no-op when no LDAP users are present", func() {
+			probeCalls := 0
+			probe := func(name string) (bool, string, error) {
+				probeCalls++
+				return true, "", nil
+			}
+			runLDAPLivenessCheck(context.Background(), ds, probe)
+
+			Expect(probeCalls).To(Equal(0))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Closes #8.

Adds a recurring background sweep that reconciles every LDAP-backed user against the configured directory and revokes the app passwords of users that have been removed (or are flagged disabled). Combined with PR #11's empty stored password, this is the lockout mechanism for offboarded LDAP accounts — once their app passwords are gone, they have no credential for the Subsonic API, and they cannot fall back to a local password at `/auth/login`.

### Configuration

Two new fields on `conf.Server.LDAP`:

| Env var | Description |
| --- | --- |
| `ND_LDAP_LIVENESSSCHEDULE` | Scheduler spec — duration like `"5m"` or a full crontab. Empty disables. Validated at startup via the existing `validateSchedule` helper. |
| `ND_LDAP_DISABLEDFILTER`   | Optional LDAP filter clause ANDed with `SearchFilter` to identify entries that exist but should be treated as disabled (AD's `userAccountControl` bit, a custom `loginShell` match, etc.). Applies to the user's own attributes — does NOT take a `%s`. |

### Behavior

- The sweep loads every user with `auth_type='ldap'` and probes each one in the directory.
- A user is considered active if (a) the directory has an entry matching `SearchFilter` AND (b) the entry does NOT match `DisabledFilter` (when set).
- Inactive users have all their app passwords soft-revoked via `RevokeAllForUser`. The revocation is logged at INFO with username, reason (`missing` or `disabled`), and count.
- **Fail-safe** on directory-wide errors: if dial or service-account bind fails, the run is aborted without revoking anything. Per-user search errors log a warning and skip just that user.
- **Defense-in-depth**: the loop double-checks `u.IsLDAP()` per user even though `GetAll` is filtered by `auth_type`, so a future caller cannot widen the query and accidentally revoke local users' app passwords.

### Code structure

- `server/ldap_liveness.go` — `LDAPLivenessCheck` (top-level, sets up the LDAP connection) delegates to `runLDAPLivenessCheck`, which is the testable core that takes a `livenessProbe` function. The production probe issues two LDAP searches per user; tests substitute fakes.
- `cmd/root.go` — `scheduleLDAPLivenessCheck` wires the job into the startup errgroup, mirroring `schedulePeriodicScan`.
- `conf/configuration.go` — new fields + `validateLDAPLivenessSchedule` registered with the existing validation chain.

### Tests

- Top-level: no-op when `LDAP.Host` is empty; aborts on dial failure without revoking.
- Core loop: revokes on `missing`, revokes on `disabled`, does NOT revoke on transient probe error, ignores non-LDAP users that slip through `GetAll`, no-op when no LDAP users exist.

## Test plan

- [x] \`go build -tags=netgo,sqlite_fts5 ./...\` clean
- [x] \`make test PKG="./server/... ./conf/... ./model/... ./persistence/..."\` — all pass
- [x] \`make format\` — no diffs
- [x] \`make lint\` — 0 issues
- [ ] Manual: configure \`ND_LDAP_LIVENESSSCHEDULE=1m\`, remove an LDAP user from the directory, observe app passwords revoked at the next tick and the lockout-revocation log line emitted.
- [ ] Manual: configure \`ND_LDAP_DISABLEDFILTER\` against a known disabled-user attribute, verify their app passwords get revoked.
- [ ] Manual: stop the LDAP server mid-tick — verify the run aborts with a warning and no revocations occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)