### PR TITLE
feat: map LDAP group membership to admin role

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ The sweep is fail-safe: if the directory is unreachable or the service-account b
 
 The interval is the lockout window operators are accepting — pick something that matches the urgency of your offboarding policy. The default is disabled (no sweep).
 
-### TODO
+### Admin role from LDAP
 
-- [ ] Add the ability to auto-assign admins using an LDAP group
+When `ND_LDAP_ADMINGROUP` (or the more flexible `ND_LDAP_ADMINFILTER`) is set, Navidrome treats the directory as the source of truth for admin membership. On every LDAP login *and* on every liveness-check tick, the user's admin status is recomputed: members of the configured group become admins, non-members are demoted. A failed admin lookup never demotes — the previous value is preserved so a transient directory hiccup can't lock the operator out.
+
+> [!IMPORTANT]
+> Add your existing Navidrome admin to the configured admin group **before** enabling this feature, otherwise the next login will demote them.
 
 ### Docker Container
 
@@ -117,6 +120,8 @@ You can configure LDAP using the following environment variables:
 | `ND_LDAP_MAIL` | The LDAP attribute to map to the user's email | `mail` |
 | `ND_LDAP_LIVENESSSCHEDULE` | How often the liveness sweep runs. Accepts a duration (`5m`, `1h`) or a full crontab. Empty disables the sweep. | `15m` |
 | `ND_LDAP_DISABLEDFILTER` | Optional LDAP filter ANDed with `SearchFilter` to flag disabled entries. The filter applies to the user's own attributes — it does not take a `%s`. | `(loginShell=/sbin/nologin)` |
+| `ND_LDAP_ADMINGROUP` | DN of an LDAP group whose members should be Navidrome admins. When set, IsAdmin is recomputed against the directory on every login + liveness sweep. | `cn=nd-admins,ou=groups,dc=example,dc=org` |
+| `ND_LDAP_ADMINFILTER` | Alternative to `AdminGroup` for directories that don't expose `memberOf`. MUST contain `%s` for the username. | `(&(memberOf=cn=nd-admins,...)(uid=%s))` |
 
 ## Translations
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -195,6 +195,20 @@ type ldapOptions struct {
 	// that has been removed. The filter applies to the user's own
 	// attributes — it is NOT formatted with the username.
 	DisabledFilter string
+
+	// AdminGroup is the DN of an LDAP group whose members should be
+	// granted Navidrome admin. When set, IsAdmin is recomputed against
+	// the directory on every LDAP login and on every liveness sweep —
+	// becoming the single source of truth for admin membership. The
+	// search uses `(&(memberOf=<AdminGroup>)<SearchFilter for user>)`.
+	// Mutually exclusive with AdminFilter (AdminGroup wins if both set).
+	AdminGroup string
+	// AdminFilter is an alternative to AdminGroup for directories that
+	// don't expose `memberOf` or for more complex admin-membership rules.
+	// The filter MUST contain `%s`, which is replaced by the escaped
+	// username, mirroring SearchFilter. Example:
+	// `(&(memberOf=cn=nd-admins,ou=groups,dc=example,dc=org)(uid=%s))`.
+	AdminFilter string
 }
 
 type TagConf struct {

--- a/server/auth.go
+++ b/server/auth.go
@@ -230,6 +230,24 @@ func validateLoginLDAP(userRepo model.UserRepository, userName, password string)
 	}
 
 	entry := sr.Entries[0]
+
+	// Admin-group check (if configured). Run BEFORE the user-bind, while
+	// the connection is still authenticated as the service account —
+	// l.Bind below will replace that with the user's bind, which on many
+	// directories cannot read group memberships. The result is only
+	// applied after the user-bind succeeds.
+	var adminCheckResult *bool
+	if adminCheckEnabled() {
+		isAdmin, adminErr := ldapAdminCheck(l, userName)
+		if adminErr != nil {
+			// Transient lookup failure — preserve the existing IsAdmin
+			// to avoid locking the operator out from a directory hiccup.
+			log.Warn("LDAP admin lookup failed; preserving existing IsAdmin", "user", userName, adminErr)
+		} else {
+			adminCheckResult = &isAdmin
+		}
+	}
+
 	// Re-bind as the user to verify their password
 	if err := l.Bind(entry.DN, password); err != nil {
 		log.Warn("LDAP user authentication failed", "user", userName, err)
@@ -251,6 +269,9 @@ func validateLoginLDAP(userRepo model.UserRepository, userName, password string)
 	u.Name = entry.GetAttributeValue(nameAttr)
 	u.Email = entry.GetAttributeValue(mailAttr)
 	u.AuthType = model.AuthTypeLDAP
+	if adminCheckResult != nil {
+		u.IsAdmin = *adminCheckResult
+	}
 	if err := userRepo.Put(u); err != nil {
 		log.Error("Could not save LDAP user", "user", userName, err)
 		return nil, nil

--- a/server/ldap_admin.go
+++ b/server/ldap_admin.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/go-ldap/ldap"
+	"github.com/navidrome/navidrome/conf"
+)
+
+// adminCheckEnabled reports whether the operator has configured an
+// LDAP-driven admin policy. When this returns false, the login flow
+// and the liveness sweep leave IsAdmin alone — the value persisted in
+// the user table is authoritative.
+func adminCheckEnabled() bool {
+	return conf.Server.LDAP.AdminGroup != "" || conf.Server.LDAP.AdminFilter != ""
+}
+
+// buildAdminFilter constructs the LDAP filter used to determine
+// whether the named user is an admin. Returns "" if no admin policy is
+// configured (caller must check adminCheckEnabled first). Extracted as
+// a pure function so the filter shape can be unit-tested without an
+// LDAP connection.
+func buildAdminFilter(userName string) string {
+	escaped := ldap.EscapeFilter(userName)
+	if g := conf.Server.LDAP.AdminGroup; g != "" {
+		userFilter := fmt.Sprintf(conf.Server.LDAP.SearchFilter, escaped)
+		return "(&(memberOf=" + ldap.EscapeFilter(g) + ")" + userFilter + ")"
+	}
+	if af := conf.Server.LDAP.AdminFilter; af != "" {
+		return fmt.Sprintf(af, escaped)
+	}
+	return ""
+}
+
+// ldapAdminCheck searches the directory to determine whether the named
+// user should be granted Navidrome admin. The bound LDAP connection l
+// must already be authenticated as the service account — group-membership
+// reads typically require it. Caller MUST first check adminCheckEnabled()
+// and skip this call when no admin policy is set.
+//
+// On a transient lookup error, callers MUST preserve the existing
+// IsAdmin value rather than demote — this avoids a directory hiccup
+// silently locking the operator out of admin functions.
+func ldapAdminCheck(l *ldap.Conn, userName string) (isAdmin bool, err error) {
+	filter := buildAdminFilter(userName)
+	if filter == "" {
+		// Caller should have checked adminCheckEnabled. Treat as no-op.
+		return false, nil
+	}
+	sr, err := l.Search(ldap.NewSearchRequest(
+		conf.Server.LDAP.Base, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		filter, []string{"dn"}, nil,
+	))
+	if err != nil {
+		return false, err
+	}
+	return len(sr.Entries) > 0, nil
+}

--- a/server/ldap_admin_test.go
+++ b/server/ldap_admin_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"github.com/navidrome/navidrome/conf"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LDAP admin filter construction", func() {
+	var savedAdminGroup, savedAdminFilter, savedSearchFilter string
+
+	BeforeEach(func() {
+		savedAdminGroup = conf.Server.LDAP.AdminGroup
+		savedAdminFilter = conf.Server.LDAP.AdminFilter
+		savedSearchFilter = conf.Server.LDAP.SearchFilter
+		conf.Server.LDAP.SearchFilter = "(uid=%s)"
+	})
+
+	AfterEach(func() {
+		conf.Server.LDAP.AdminGroup = savedAdminGroup
+		conf.Server.LDAP.AdminFilter = savedAdminFilter
+		conf.Server.LDAP.SearchFilter = savedSearchFilter
+	})
+
+	Describe("adminCheckEnabled", func() {
+		It("is false when neither AdminGroup nor AdminFilter is set", func() {
+			conf.Server.LDAP.AdminGroup = ""
+			conf.Server.LDAP.AdminFilter = ""
+
+			Expect(adminCheckEnabled()).To(BeFalse())
+		})
+
+		It("is true when AdminGroup is set", func() {
+			conf.Server.LDAP.AdminGroup = "cn=admins,dc=example,dc=org"
+			conf.Server.LDAP.AdminFilter = ""
+
+			Expect(adminCheckEnabled()).To(BeTrue())
+		})
+
+		It("is true when AdminFilter is set", func() {
+			conf.Server.LDAP.AdminGroup = ""
+			conf.Server.LDAP.AdminFilter = "(memberOf=cn=admins,dc=example,dc=org)"
+
+			Expect(adminCheckEnabled()).To(BeTrue())
+		})
+	})
+
+	Describe("buildAdminFilter", func() {
+		It("returns empty when no admin policy is configured", func() {
+			conf.Server.LDAP.AdminGroup = ""
+			conf.Server.LDAP.AdminFilter = ""
+
+			Expect(buildAdminFilter("alice")).To(Equal(""))
+		})
+
+		It("uses memberOf=AdminGroup combined with the user's SearchFilter", func() {
+			conf.Server.LDAP.AdminGroup = "cn=admins,dc=example,dc=org"
+			conf.Server.LDAP.AdminFilter = ""
+
+			Expect(buildAdminFilter("alice")).To(Equal(
+				"(&(memberOf=cn=admins,dc=example,dc=org)(uid=alice))",
+			))
+		})
+
+		It("escapes filter-special characters in the username", func() {
+			conf.Server.LDAP.AdminGroup = "cn=admins,dc=example,dc=org"
+			conf.Server.LDAP.AdminFilter = ""
+
+			got := buildAdminFilter("a(lice)")
+			Expect(got).To(ContainSubstring(`uid=a\28lice\29`))
+		})
+
+		It("escapes filter-special characters in the AdminGroup DN", func() {
+			conf.Server.LDAP.AdminGroup = `cn=admins(test),dc=example,dc=org`
+			conf.Server.LDAP.AdminFilter = ""
+
+			got := buildAdminFilter("alice")
+			Expect(got).To(ContainSubstring(`memberOf=cn=admins\28test\29,dc=example,dc=org`))
+		})
+
+		It("uses AdminFilter formatted with the escaped username when AdminGroup is unset", func() {
+			conf.Server.LDAP.AdminGroup = ""
+			conf.Server.LDAP.AdminFilter = "(&(memberOf=cn=ops,dc=example,dc=org)(uid=%s))"
+
+			Expect(buildAdminFilter("bob")).To(Equal(
+				"(&(memberOf=cn=ops,dc=example,dc=org)(uid=bob))",
+			))
+		})
+
+		It("prefers AdminGroup over AdminFilter when both are set", func() {
+			conf.Server.LDAP.AdminGroup = "cn=admins,dc=example,dc=org"
+			conf.Server.LDAP.AdminFilter = "(uid=%s)"
+
+			Expect(buildAdminFilter("alice")).To(ContainSubstring("memberOf=cn=admins"))
+		})
+	})
+})

--- a/server/ldap_liveness.go
+++ b/server/ldap_liveness.go
@@ -19,6 +19,13 @@ import (
 // signal to revoke.
 type livenessProbe func(userName string) (active bool, reason string, err error)
 
+// adminProbeFn answers "should this LDAP user be a Navidrome admin?"
+// based on AdminGroup/AdminFilter configuration. nil indicates that no
+// admin policy is configured and the sweep should leave IsAdmin alone.
+// A non-nil error indicates a transient lookup failure — callers MUST
+// preserve the existing IsAdmin rather than demote.
+type adminProbeFn func(userName string) (isAdmin bool, err error)
+
 // LDAPLivenessCheck reconciles every LDAP-backed user against the
 // configured directory and revokes the app passwords of users that no
 // longer match — either because they were removed from the directory or
@@ -48,12 +55,21 @@ func LDAPLivenessCheck(ctx context.Context, ds model.DataStore) {
 		return
 	}
 
-	runLDAPLivenessCheck(ctx, ds, ldapProbe(l))
+	var adminProbe adminProbeFn
+	if adminCheckEnabled() {
+		adminProbe = func(userName string) (bool, error) {
+			return ldapAdminCheck(l, userName)
+		}
+	}
+	runLDAPLivenessCheck(ctx, ds, ldapProbe(l), adminProbe)
 }
 
 // runLDAPLivenessCheck is the testable core: given a probe, walk every
 // LDAP-backed user and revoke app passwords for ones that don't pass.
-func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenessProbe) {
+// When adminProbe is non-nil, IsAdmin is also recomputed against the
+// directory and persisted on change. A transient adminProbe error
+// preserves the existing IsAdmin rather than demoting.
+func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenessProbe, adminProbe adminProbeFn) {
 	userRepo := ds.User(ctx)
 	users, err := userRepo.GetAll(model.QueryOptions{
 		Filters: squirrel.Eq{"auth_type": model.AuthTypeLDAP},
@@ -69,6 +85,7 @@ func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenes
 	appRepo := ds.AppPassword(ctx)
 	checked := 0
 	revoked := 0
+	adminChanged := 0
 	for _, u := range users {
 		// Defense-in-depth: the SQL filter above should have done this,
 		// but never revoke a local user's app passwords just because a
@@ -82,20 +99,40 @@ func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenes
 			continue
 		}
 		checked++
-		if active {
-			continue
+
+		if !active {
+			n, revokeErr := appRepo.RevokeAllForUser(u.ID)
+			if revokeErr != nil {
+				log.Error(ctx, "LDAP liveness: failed to revoke app passwords", "user", u.UserName, revokeErr)
+			} else {
+				revoked++
+				log.Info(ctx, "LDAP liveness: revoked app passwords for user no longer authorized",
+					"user", u.UserName, "reason", reason, "appPasswords", n)
+			}
 		}
 
-		n, err := appRepo.RevokeAllForUser(u.ID)
-		if err != nil {
-			log.Error(ctx, "LDAP liveness: failed to revoke app passwords", "user", u.UserName, err)
-			continue
+		// Recompute admin membership when configured. We do this for
+		// inactive users too: if a removed-from-directory admin later
+		// returns without re-validation, their stale IsAdmin should
+		// already be cleared.
+		if adminProbe != nil {
+			newIsAdmin, adminErr := adminProbe(u.UserName)
+			if adminErr != nil {
+				log.Warn(ctx, "LDAP liveness: admin probe failed; preserving IsAdmin", "user", u.UserName, adminErr)
+			} else if u.IsAdmin != newIsAdmin {
+				u.IsAdmin = newIsAdmin
+				if err := ds.User(ctx).Put(&u); err != nil {
+					log.Error(ctx, "LDAP liveness: failed to persist IsAdmin change", "user", u.UserName, err)
+				} else {
+					adminChanged++
+					log.Info(ctx, "LDAP liveness: updated IsAdmin from directory",
+						"user", u.UserName, "isAdmin", newIsAdmin)
+				}
+			}
 		}
-		revoked++
-		log.Info(ctx, "LDAP liveness: revoked app passwords for user no longer authorized",
-			"user", u.UserName, "reason", reason, "appPasswords", n)
 	}
-	log.Debug(ctx, "LDAP liveness: run complete", "users", len(users), "checked", checked, "revoked", revoked)
+	log.Debug(ctx, "LDAP liveness: run complete",
+		"users", len(users), "checked", checked, "revoked", revoked, "adminChanged", adminChanged)
 }
 
 // ldapProbe builds a livenessProbe that consults the given LDAP

--- a/server/ldap_liveness_test.go
+++ b/server/ldap_liveness_test.go
@@ -83,7 +83,7 @@ var _ = Describe("LDAP liveness check", func() {
 				}
 				return true, "", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
 
 			Expect(activeCount("u-missing")).To(Equal(0))
 			Expect(activeCount("u-active")).To(Equal(1))
@@ -95,7 +95,7 @@ var _ = Describe("LDAP liveness check", func() {
 			probe := func(name string) (bool, string, error) {
 				return false, "disabled", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
 
 			Expect(activeCount("u-disabled")).To(Equal(0))
 		})
@@ -106,7 +106,7 @@ var _ = Describe("LDAP liveness check", func() {
 			probe := func(name string) (bool, string, error) {
 				return false, "", errors.New("transient ldap search failure")
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
 
 			Expect(activeCount("u-flaky")).To(Equal(1))
 		})
@@ -127,7 +127,7 @@ var _ = Describe("LDAP liveness check", func() {
 			probe := func(name string) (bool, string, error) {
 				return false, "missing", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
 
 			Expect(activeCount("u-local")).To(Equal(1))
 		})
@@ -138,9 +138,81 @@ var _ = Describe("LDAP liveness check", func() {
 				probeCalls++
 				return true, "", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
 
 			Expect(probeCalls).To(Equal(0))
+		})
+	})
+
+	Context("admin recompute", func() {
+		alwaysActive := func(name string) (bool, string, error) {
+			return true, "", nil
+		}
+
+		It("promotes a user added to the admin group", func() {
+			seedLDAPUser("u-promote", "promote-me")
+			adminProbe := func(name string) (bool, error) { return true, nil }
+
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+
+			got, err := users.Get("u-promote")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.IsAdmin).To(BeTrue())
+		})
+
+		It("demotes a user removed from the admin group", func() {
+			Expect(users.Put(&model.User{
+				ID:       "u-demote",
+				UserName: "demote-me",
+				AuthType: model.AuthTypeLDAP,
+				IsAdmin:  true,
+			})).To(Succeed())
+			adminProbe := func(name string) (bool, error) { return false, nil }
+
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+
+			got, err := users.Get("u-demote")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.IsAdmin).To(BeFalse())
+		})
+
+		It("preserves IsAdmin when the admin probe returns an error", func() {
+			Expect(users.Put(&model.User{
+				ID:       "u-flaky-admin",
+				UserName: "flakyadmin",
+				AuthType: model.AuthTypeLDAP,
+				IsAdmin:  true,
+			})).To(Succeed())
+			adminProbe := func(name string) (bool, error) {
+				return false, errors.New("transient ldap admin lookup failure")
+			}
+
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+
+			got, err := users.Get("u-flaky-admin")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.IsAdmin).To(BeTrue())
+		})
+
+		It("demotes inactive users that were admin", func() {
+			Expect(users.Put(&model.User{
+				ID:       "u-gone-admin",
+				UserName: "gone",
+				AuthType: model.AuthTypeLDAP,
+				IsAdmin:  true,
+			})).To(Succeed())
+			Expect(appPwds.Put(&model.AppPassword{
+				UserID: "u-gone-admin", Name: "iPad", NewPassword: "p",
+			})).To(Succeed())
+			missing := func(name string) (bool, string, error) { return false, "missing", nil }
+			adminProbe := func(name string) (bool, error) { return false, nil }
+
+			runLDAPLivenessCheck(context.Background(), ds, missing, adminProbe)
+
+			got, err := users.Get("u-gone-admin")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.IsAdmin).To(BeFalse())
+			Expect(activeCount("u-gone-admin")).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Closes #9.

When `ND_LDAP_ADMINGROUP` (DN form) or `ND_LDAP_ADMINFILTER` (raw filter form, `%s`-parameterized for the username) is set, the configured LDAP directory becomes the source of truth for Navidrome admin membership. `IsAdmin` is recomputed:

- **On every LDAP login** (\`validateLoginLDAP\`) — the lookup runs against the still-bound service account before the user-bind replaces the bind context, and the result is only applied after password verification succeeds.
- **On every liveness-sweep tick** (extending #8) — the sweep now also carries an \`adminProbeFn\` alongside the presence probe; an admin-membership change triggers a Put to persist the new \`IsAdmin\`.

**Fail-safe**: a transient admin lookup error preserves the existing \`IsAdmin\` rather than demoting, so a directory hiccup cannot lock operators out.

> [!IMPORTANT]
> Add your existing Navidrome admin to the configured admin group **before** enabling this feature, otherwise the next login will demote them.

### Configuration

| Env var | Description |
| --- | --- |
| \`ND_LDAP_ADMINGROUP\` | DN of an LDAP group whose members should be Navidrome admins. Search uses \`(&(memberOf=<AdminGroup>)<SearchFilter for user>)\`. |
| \`ND_LDAP_ADMINFILTER\` | Alternative for directories that don't expose \`memberOf\` or for more complex rules. MUST contain \`%s\` for the username. |

\`AdminGroup\` wins if both are set.

### Code structure

- \`conf/configuration.go\` — two new fields on \`ldapOptions\`.
- \`server/ldap_admin.go\` — \`adminCheckEnabled()\`, \`buildAdminFilter()\` (pure, unit-tested), \`ldapAdminCheck()\` (LDAP search wrapper). Filter building is extracted as a pure function so the construction logic is testable without an LDAP server (this also addresses the test-coverage pattern flagged in #13 for the existing liveness probe).
- \`server/auth.go\` — admin lookup hooked into \`validateLoginLDAP\` at the point where the service-account bind is still active.
- \`server/ldap_liveness.go\` — \`runLDAPLivenessCheck\` takes a new \`adminProbeFn\` parameter; the loop recomputes \`IsAdmin\` for every LDAP user when the probe is non-nil. \`LDAPLivenessCheck\` builds the production probe only when \`adminCheckEnabled()\`.

### Tests

- \`server/ldap_admin_test.go\` — 9 specs: \`adminCheckEnabled\` (3), \`buildAdminFilter\` (6 covering AdminGroup form, AdminFilter form, username escape, DN escape, AdminGroup-wins precedence, and the empty-when-unconfigured case).
- \`server/ldap_liveness_test.go\` — 4 new specs in an \"admin recompute\" context: promote, demote, error-preserves, demote-of-inactive-admin (covers the issue's \"liveness job recomputes IsAdmin for all LDAP users\" criterion).

### Acceptance criteria from #9

- [x] \`AdminGroup\` and \`AdminFilter\` config fields documented in \`README.md\`.
- [x] \`IsAdmin\` is recomputed on every LDAP login when config is set.
- [x] Liveness job recomputes \`IsAdmin\` for all LDAP users.
- [x] LDAP lookup failures do not cause demotion.
- [x] Test coverage for: user in group → admin, user not in group → not admin, LDAP error → state preserved.

## Test plan

- [x] \`go build -tags=netgo,sqlite_fts5 ./...\` clean
- [x] \`make test PKG=\"./server/... ./conf/... ./model/... ./persistence/...\"\` — all pass
- [x] \`make format\` — no diffs
- [x] \`make lint\` — 0 issues
- [ ] Manual: configure \`ND_LDAP_ADMINGROUP\`, log in as a member — verify IsAdmin set; log in as a non-member — verify IsAdmin cleared.
- [ ] Manual: with \`ND_LDAP_LIVENESSSCHEDULE=1m\` and \`ND_LDAP_ADMINGROUP\` set, add/remove a user from the admin group — verify the next sweep promotes/demotes.
- [ ] Manual: stop LDAP between admin search and user-bind (or vice versa) — verify IsAdmin is preserved on transient errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)