### PR TITLE
fix(ui): authenticate /rest/* via JWT instead of salt+token

### DIFF
--- a/server/subsonic/app_password_auth_test.go
+++ b/server/subsonic/app_password_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 
+	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/tests"
@@ -250,6 +251,27 @@ var _ = Describe("App Password Subsonic Auth", func() {
 
 			Expect(nextHandler.called).To(BeFalse())
 			Expect(w.Body.String()).To(ContainSubstring(`code="40"`))
+		})
+
+		// Regression for the bug PR #20 fixes: LDAP users have an empty
+		// stored password, so salt+token over the empty password is
+		// rejected by the LDAP-app-password gate. The web UI uses JWT
+		// (?jwt=) instead — verify it works end-to-end through the
+		// authenticate middleware for an LDAP user with no app password
+		// in play.
+		It("accepts a JWT minted for the LDAP user", func() {
+			auth.Init(ds)
+			ldapUsr, err := ds.User(context.TODO()).FindByUsername(ldapUser)
+			Expect(err).ToNot(HaveOccurred())
+			jwt, err := auth.CreateToken(ldapUsr)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := newGetRequest("u="+ldapUser, "jwt="+jwt)
+			authenticate(ds)(nextHandler).ServeHTTP(w, r)
+
+			Expect(nextHandler.called).To(BeTrue())
+			user, _ := request.UserFrom(nextHandler.req.Context())
+			Expect(user.UserName).To(Equal(ldapUser))
 		})
 	})
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -3,16 +3,21 @@ import { httpClient } from '../dataProvider'
 
 const url = (command, id, options) => {
   const username = localStorage.getItem('username')
-  const token = localStorage.getItem('subsonic-token')
-  const salt = localStorage.getItem('subsonic-salt')
-  if (!username || !token || !salt) {
+  const jwt = localStorage.getItem('token')
+  if (!username || !jwt) {
     return ''
   }
 
+  // Authenticate /rest/* via the JWT minted by /auth/login. The legacy
+  // salt+token path (md5(user.Password + salt)) doesn't work for
+  // LDAP-backed users — they have an empty stored password by design,
+  // so the token resolves to md5(salt) which the server-side gate
+  // correctly rejects as forgeable. JWT is server-signed, bound to the
+  // user via Subject claim, and validated by the existing JWT arm of
+  // validateCredentials — same auth surface for local and LDAP users.
   const params = new URLSearchParams()
   params.append('u', username)
-  params.append('t', token)
-  params.append('s', salt)
+  params.append('jwt', jwt)
   params.append('f', 'json')
   params.append('v', '1.8.0')
   params.append('c', 'NavidromeUI')

--- a/ui/src/subsonic/index.test.js
+++ b/ui/src/subsonic/index.test.js
@@ -13,8 +13,7 @@ describe('getCoverArtUrl', () => {
       getItem: vi.fn((key) => {
         const values = {
           username: 'testuser',
-          'subsonic-token': 'testtoken',
-          'subsonic-salt': 'testsalt',
+          token: 'test-jwt-token',
         }
         return values[key] || null
       }),
@@ -128,8 +127,7 @@ describe('getDiscCoverArtUrl', () => {
       getItem: vi.fn((key) => {
         const values = {
           username: 'testuser',
-          'subsonic-token': 'testtoken',
-          'subsonic-salt': 'testsalt',
+          token: 'test-jwt-token',
         }
         return values[key] || null
       }),
@@ -172,6 +170,43 @@ describe('getDiscCoverArtUrl', () => {
   })
 })
 
+describe('auth params', () => {
+  beforeEach(() => {
+    delete window.location
+    window.location = { href: 'http://localhost:3000/app' }
+  })
+
+  it('uses JWT (?jwt=) and never sends salt+token (?s=, ?t=)', () => {
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        const values = { username: 'testuser', token: 'jwt-abc' }
+        return values[key] || null
+      }),
+    }
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+    const url = subsonic.getCoverArtUrl({ id: 'a' }, 100)
+
+    expect(url).toContain('u=testuser')
+    expect(url).toContain('jwt=jwt-abc')
+    expect(url).not.toContain('&s=')
+    expect(url).not.toContain('&t=')
+  })
+
+  it('returns an empty url when JWT is missing (e.g. logged out)', () => {
+    const localStorageMock = {
+      getItem: vi.fn((key) => (key === 'username' ? 'testuser' : null)),
+    }
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+    // url() returns '' when auth is missing; baseUrl('') resolves to '/'.
+    // The point is that no /rest/* request gets constructed.
+    expect(subsonic.getCoverArtUrl({ id: 'a' }, 100)).not.toContain(
+      'getCoverArt',
+    )
+  })
+})
+
 describe('getAvatarUrl', () => {
   beforeEach(() => {
     // Mock localStorage values required by subsonic
@@ -179,8 +214,7 @@ describe('getAvatarUrl', () => {
       getItem: vi.fn((key) => {
         const values = {
           username: 'testuser',
-          'subsonic-token': 'testtoken',
-          'subsonic-salt': 'testsalt',
+          token: 'test-jwt-token',
         }
         return values[key] || null
       }),

--- a/ui/src/transcode/decisionService.test.js
+++ b/ui/src/transcode/decisionService.test.js
@@ -64,8 +64,8 @@ describe('decisionService', () => {
 
   beforeEach(() => {
     localStorage.setItem('username', 'testuser')
-    localStorage.setItem('subsonic-token', 'testtoken')
-    localStorage.setItem('subsonic-salt', 'testsalt')
+    localStorage.setItem('token', 'test-jwt-token')
+
     mockFetchFn = vi.fn().mockImplementation(() => {
       return Promise.resolve(makeFakeDecision())
     })

--- a/ui/src/transcode/fetchDecision.test.js
+++ b/ui/src/transcode/fetchDecision.test.js
@@ -33,8 +33,7 @@ describe('fetchTranscodeDecision', () => {
 
   beforeEach(() => {
     localStorage.setItem('username', 'testuser')
-    localStorage.setItem('subsonic-token', 'testtoken')
-    localStorage.setItem('subsonic-salt', 'testsalt')
+    localStorage.setItem('token', 'test-jwt-token')
 
     httpClient.mockResolvedValue({ json: fakeJson })
   })


### PR DESCRIPTION
## Symptom

After deploying #10/#11/#12/#16 to a production-like stack and logging in as an LDAP user, the web UI loaded but every cover-art request returned 401:

\`\`\`
{\"subsonic-response\":{\"status\":\"failed\",\"error\":{\"code\":40,\"message\":\"Wrong username or password\"}}}
\`\`\`

Server logs showed PR #11's gate firing on the web UI's own requests:

\`\`\`
\"API: Rejecting non-app-password Subsonic auth for LDAP user\" username=joestump
\`\`\`

## Root cause

PR #11 cleared LDAP-backed users' password column. The React UI computes \`subsonicToken = md5(user.Password + subsonicSalt)\`. For LDAP users this becomes \`md5(\"\" + salt) = md5(salt)\` — a value anyone with the salt can forge. PR #11's auth gate at \`server/subsonic/middlewares.go:159\` correctly rejects it as \"no valid app password\". But that gate fires for the React UI itself, because the React UI authenticates \`/rest/*\` calls (cover art, scrobble, star, scan, etc.) with the same salt+token scheme via \`ui/src/subsonic/index.js\`.

The security review for #11 had this as a candidate finding (\"JWT-as-Subsonic-credential bypasses the LDAP app-password gate\") but the filter pass dismissed it because it assumed \"the web UI calls /rest/* endpoints with ?jwt=\" — which turned out to be false. The web UI uses salt+token. We missed the regression.

## Fix

Switch \`ui/src/subsonic/index.js\` to send the JWT (\`?u=&jwt=\`) instead of \`?u=&t=&s=\`. The JWT is already in \`localStorage.token\` (populated by \`authProvider.js\` from \`/auth/login\`'s response). Server-side, the existing JWT arm of \`validateCredentials\` (\`server/subsonic/middlewares.go:209-211\`) handles it — no Go change needed.

This is using an upstream-supported auth method, not introducing a new path. The JWT case in \`validateCredentials\` predates this fork.

### Behavior change for local users

Local users also switch to JWT. Functionally equivalent — JWT path is well-tested upstream and bound to user via Subject claim. The \`subsonicSalt\`/\`subsonicToken\` fields remain in the \`/auth/login\` response for backward compat (in case anyone consumes the payload outside the React UI).

## Tests

- \`ui/src/subsonic/index.test.js\` — rewrite localStorage mocks (\`token\` not \`subsonic-token\`/\`subsonic-salt\`); two new specs lock in the JWT-only contract: (a) URLs always contain \`u=\` and \`jwt=\`, never \`s=\`/\`t=\`; (b) when JWT is missing, no \`/rest/*\` URL is constructed.
- \`ui/src/transcode/{decisionService,fetchDecision}.test.js\` — same mock update.

## Test plan

- [x] \`npm test\` (UI) — 495/495 pass
- [x] \`go build -tags=netgo,sqlite_fts5 ./...\` clean
- [x] \`make lint\` — 0 issues
- [x] \`make format\` — no diffs
- [ ] Manual: redeploy on a stack with an LDAP user; cover art renders, scrobbles fire, star/unstar works.
- [ ] Manual: local-user login still functional end-to-end (cover art, playback, scrobbling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)