### PR TITLE
feat(ui): split App Passwords into a Security pane; lock LDAP-managed fields

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -164,7 +164,8 @@
       },
       "helperTexts": {
         "name": "Changes to your name will only be reflected on next login",
-        "libraries": "Select specific libraries for this user, or leave empty to use default libraries"
+        "libraries": "Select specific libraries for this user, or leave empty to use default libraries",
+        "ldapManagedField": "Managed by LDAP — overwritten on every login"
       },
       "notifications": {
         "created": "User created",
@@ -195,7 +196,7 @@
         "appPasswordOneTime": "Save this secret now — it will not be shown again. Paste it into your Subsonic client in place of your account password.",
         "appPasswordActive": "Active",
         "appPasswordRevoked": "Revoked",
-        "ldapManagedPassword": "This account authenticates against LDAP. Sign in with your directory password and use an app password (below) for Subsonic clients."
+        "ldapManagedPassword": "This account authenticates against LDAP. Sign in with your directory password; for Subsonic clients, generate an app password from the Security page."
       }
     },
     "player": {
@@ -636,6 +637,10 @@
     "settings": "Settings",
     "version": "Version",
     "theme": "Theme",
+    "security": {
+      "name": "Security",
+      "intro": "Manage credentials for this account. App passwords are per-device, revocable, and independent of your account password — paste them into Subsonic-compatible clients in place of your password."
+    },
     "personal": {
       "name": "Personal",
       "options": {

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -13,6 +13,7 @@ import ViewListIcon from '@material-ui/icons/ViewList'
 import { Dialogs } from '../dialogs/Dialogs'
 import { AboutDialog } from '../dialogs'
 import PersonalMenu from './PersonalMenu'
+import SecurityMenu from './SecurityMenu'
 import ActivityPanel from './ActivityPanel'
 import NowPlayingPanel from './NowPlayingPanel'
 import UserMenu from './UserMenu'
@@ -128,6 +129,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />
         <Divider />
         {renderUserMenuItemLink()}
+        <SecurityMenu sidebarIsOpen={true} onClick={onClick} />
         {resources
           .filter(settingsResources)
           .map((r) => renderSettingsMenuItemLink(r))}

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -25,6 +25,9 @@ vi.mock('./ActivityPanel', () => ({
 vi.mock('./PersonalMenu', () => ({
   default: () => <div />,
 }))
+vi.mock('./SecurityMenu', () => ({
+  default: () => <div />,
+}))
 vi.mock('./UserMenu', () => ({
   default: ({ children }) => <div>{children}</div>,
 }))

--- a/ui/src/layout/SecurityMenu.jsx
+++ b/ui/src/layout/SecurityMenu.jsx
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react'
+import { MenuItemLink, useTranslate } from 'react-admin'
+import { MdLock } from 'react-icons/md'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  menuItem: {
+    color: theme.palette.text.secondary,
+  },
+}))
+
+const SecurityMenu = forwardRef(({ onClick, sidebarIsOpen, dense }, ref) => {
+  const translate = useTranslate()
+  const classes = useStyles()
+  return (
+    <MenuItemLink
+      ref={ref}
+      to="/security"
+      primaryText={translate('menu.security.name')}
+      leftIcon={<MdLock size={24} />}
+      onClick={onClick}
+      className={classes.menuItem}
+      sidebarIsOpen={sidebarIsOpen}
+      dense={dense}
+    />
+  )
+})
+
+SecurityMenu.displayName = 'SecurityMenu'
+
+export default SecurityMenu

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import Security from './security/Security'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route exact path="/security" render={() => <Security />} key={'security'} />,
 ]
 
 export default routes

--- a/ui/src/security/Security.jsx
+++ b/ui/src/security/Security.jsx
@@ -1,0 +1,34 @@
+import { Title, useTranslate } from 'react-admin'
+import { Card, CardContent, Typography } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import { AppPasswordPanel } from '../user/AppPasswordPanel'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginTop: theme.spacing(2),
+  },
+  intro: {
+    marginBottom: theme.spacing(2),
+    color: theme.palette.text.secondary,
+  },
+}))
+
+const Security = () => {
+  const translate = useTranslate()
+  const classes = useStyles()
+  const userId = localStorage.getItem('userId')
+
+  return (
+    <Card className={classes.root}>
+      <Title title={'Navidrome - ' + translate('menu.security.name')} />
+      <CardContent>
+        <Typography variant="body2" className={classes.intro}>
+          {translate('menu.security.intro')}
+        </Typography>
+        <AppPasswordPanel userId={userId} />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default Security

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -24,7 +24,6 @@ import { Typography } from '@material-ui/core'
 import { Title } from '../common'
 import DeleteUserButton from './DeleteUserButton'
 import { LibrarySelectionField } from './LibrarySelectionField.jsx'
-import { AppPasswordPanel } from './AppPasswordPanel.jsx'
 import { validateUserForm } from './userValidation'
 
 const useStyles = makeStyles({
@@ -75,11 +74,12 @@ const UserEdit = (props) => {
   const refresh = useRefresh()
 
   const isMyself = props.id === localStorage.getItem('userId')
-  const getNameHelperText = () =>
-    isMyself && {
-      helperText: translate('resources.user.helperTexts.name'),
-    }
   const canDelete = permissions === 'admin' && !isMyself
+  const nameHelperText = (ldap) => {
+    if (ldap) return translate('resources.user.helperTexts.ldapManagedField')
+    if (isMyself) return translate('resources.user.helperTexts.name')
+    return undefined
+  }
 
   const save = useCallback(
     async (values) => {
@@ -118,18 +118,42 @@ const UserEdit = (props) => {
         save={save}
         validate={validateForm}
       >
-        {permissions === 'admin' && (
-          <TextInput
-            spellCheck={false}
-            source="userName"
-            validate={[required()]}
-          />
-        )}
-        <TextInput
-          source="name"
-          validate={[required()]}
-          {...getNameHelperText()}
-        />
+        <FormDataConsumer>
+          {({ formData }) => {
+            const ldap = formData.authType === 'ldap'
+            // For LDAP-backed users the directory is the source of
+            // truth — userName and name get rewritten on every login
+            // from the LDAP attributes, so editing them locally is at
+            // best transient and at worst confusing. Render them
+            // disabled (admins still see the field, but can't change
+            // it) so it's clear why.
+            return (
+              <>
+                {permissions === 'admin' && (
+                  <TextInput
+                    spellCheck={false}
+                    source="userName"
+                    validate={[required()]}
+                    disabled={ldap}
+                    helperText={
+                      ldap
+                        ? translate(
+                            'resources.user.helperTexts.ldapManagedField',
+                          )
+                        : undefined
+                    }
+                  />
+                )}
+                <TextInput
+                  source="name"
+                  validate={[required()]}
+                  disabled={ldap}
+                  helperText={nameHelperText(ldap)}
+                />
+              </>
+            )
+          }}
+        </FormDataConsumer>
         <TextInput spellCheck={false} source="email" validate={[email()]} />
         <FormDataConsumer>
           {({ formData }) =>
@@ -184,8 +208,6 @@ const UserEdit = (props) => {
         <DateField variant="body1" source="lastAccessAt" showTime />
         <DateField variant="body1" source="updatedAt" showTime />
         <DateField variant="body1" source="createdAt" showTime />
-
-        <AppPasswordPanel userId={props.id} />
       </SimpleForm>
     </Edit>
   )


### PR DESCRIPTION
## Summary

UX cleanup based on field feedback after rolling out the LDAP MVP (PRs #11/#12/#16/#20):

1. **User edit page was overloaded.** App Passwords got dumped at the bottom of the user-profile form, far from anything related, with the SAVE button pushed below it.
2. **UserName + Name were editable for LDAP-backed users**, but both get overwritten by directory attributes on every login. Editing them was at best transient and at worst confusing.
3. **Security/credentials don't belong inside \"User\"** — they're a distinct concern.

## Changes

- **New \"Security\" page** at \`/security\`, with \`SecurityMenu\` in the app-bar user dropdown positioned between **User** and **Players** (matching the feedback).
- \`AppPasswordPanel\` **moves out of \`UserEdit\`** and into \`Security\` (renders for the currently-logged-in user via \`localStorage.userId\`).
- For LDAP-backed users, **\`UserName\` and \`Name\` are disabled** with a helper text explaining they're managed by the directory and overwritten on every login. Still rendered so admins can see current values, but read-only.
- LDAP-managed-password explainer updated to point at the new Security page (was \"(below)\" — no longer accurate).
- New i18n strings: \`menu.security.{name,intro}\`, \`resources.user.helperTexts.ldapManagedField\`.

## Test plan

- [x] \`npm test\` — 495/495 pass
- [x] \`npm run check-formatting\` — clean
- [x] \`npm run lint\` — clean
- [ ] Manual: log in as admin (local user), open Settings dropdown — verify Security entry appears between User and Players, page loads.
- [ ] Manual: open User → admin profile — confirm App Passwords section is gone, SAVE button is right under the form.
- [ ] Manual: log in as LDAP user — UserName + Name fields are disabled with helper text, password section shows the LDAP explainer pointing at Security page, App Passwords manageable from Security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)