### PR TITLE
fix(ui): App Passwords UX — click-to-copy, table overflow, revoke confirm

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -196,6 +196,9 @@
         "appPasswordOneTime": "Save this secret now — it will not be shown again. Paste it into your Subsonic client in place of your account password.",
         "appPasswordActive": "Active",
         "appPasswordRevoked": "Revoked",
+        "appPasswordClickToCopy": "Click to copy",
+        "appPasswordConfirmRevokeTitle": "Revoke app password?",
+        "appPasswordConfirmRevokeBody": "Any device or app using \"%{name}\" will stop working immediately. This cannot be undone.",
         "ldapManagedPassword": "This account authenticates against LDAP. Sign in with your directory password; for Subsonic clients, generate an app password from the Security page."
       }
     },

--- a/ui/src/user/AppPasswordPanel.jsx
+++ b/ui/src/user/AppPasswordPanel.jsx
@@ -12,6 +12,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
   TextField,
@@ -19,7 +20,6 @@ import {
   Typography,
 } from '@material-ui/core'
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline'
-import FileCopyIcon from '@material-ui/icons/FileCopy'
 import { useNotify, useTranslate } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import httpClient from '../dataProvider/httpClient'
@@ -30,11 +30,14 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     marginTop: theme.spacing(3),
     padding: theme.spacing(2),
+    boxSizing: 'border-box',
   },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
     marginBottom: theme.spacing(1),
   },
   empty: {
@@ -42,14 +45,29 @@ const useStyles = makeStyles((theme) => ({
     fontStyle: 'italic',
     padding: theme.spacing(2, 0),
   },
-  secretField: {
-    fontFamily: 'monospace',
+  tableWrap: {
     width: '100%',
+    overflowX: 'auto',
   },
-  secretActions: {
-    display: 'flex',
-    alignItems: 'center',
+  secret: {
+    display: 'block',
+    width: '100%',
     marginTop: theme.spacing(1),
+    padding: theme.spacing(1.5),
+    fontFamily: 'monospace',
+    fontSize: '1rem',
+    textAlign: 'left',
+    wordBreak: 'break-all',
+    backgroundColor: theme.palette.action.hover,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.text.primary,
+    cursor: 'pointer',
+    '&:hover, &:focus-visible': {
+      backgroundColor: theme.palette.action.selected,
+      borderColor: theme.palette.primary.main,
+      outline: 'none',
+    },
   },
 }))
 
@@ -68,6 +86,8 @@ export const AppPasswordPanel = ({ userId }) => {
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
   const [generated, setGenerated] = useState(null)
+  const [revokeTarget, setRevokeTarget] = useState(null)
+  const [revoking, setRevoking] = useState(false)
 
   const reload = useCallback(async () => {
     if (!userId) return
@@ -114,15 +134,21 @@ export const AppPasswordPanel = ({ userId }) => {
     }
   }
 
-  const handleRevoke = async (id) => {
+  const handleRevokeConfirmed = async () => {
+    if (!revokeTarget) return
+    setRevoking(true)
     try {
-      await httpClient(`${REST_URL}/user/${userId}/app-password/${id}`, {
-        method: 'DELETE',
-      })
+      await httpClient(
+        `${REST_URL}/user/${userId}/app-password/${revokeTarget.id}`,
+        { method: 'DELETE' },
+      )
       notify('resources.user.notifications.appPasswordRevoked', 'info')
+      setRevokeTarget(null)
       await reload()
     } catch (e) {
       notify('resources.user.notifications.appPasswordRevokeError', 'warning')
+    } finally {
+      setRevoking(false)
     }
   }
 
@@ -130,6 +156,13 @@ export const AppPasswordPanel = ({ userId }) => {
     if (navigator?.clipboard?.writeText) {
       navigator.clipboard.writeText(value)
       notify('resources.user.notifications.appPasswordCopied', 'info')
+    }
+  }
+
+  const handleSecretKeyDown = (value) => (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleCopy(value)
     }
   }
 
@@ -157,55 +190,57 @@ export const AppPasswordPanel = ({ userId }) => {
       )}
 
       {items.length > 0 && (
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                {translate('resources.user.fields.appPasswordName')}
-              </TableCell>
-              <TableCell>
-                {translate('resources.user.fields.appPasswordCreatedAt')}
-              </TableCell>
-              <TableCell>
-                {translate('resources.user.fields.appPasswordLastUsedAt')}
-              </TableCell>
-              <TableCell>
-                {translate('resources.user.fields.appPasswordStatus')}
-              </TableCell>
-              <TableCell align="right" />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {items.map((row) => (
-              <TableRow key={row.id}>
-                <TableCell>{row.name}</TableCell>
-                <TableCell>{formatDate(row.createdAt)}</TableCell>
-                <TableCell>{formatDate(row.lastUsedAt)}</TableCell>
+        <TableContainer className={classes.tableWrap}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
                 <TableCell>
-                  {row.revokedAt
-                    ? translate('resources.user.message.appPasswordRevoked')
-                    : translate('resources.user.message.appPasswordActive')}
+                  {translate('resources.user.fields.appPasswordName')}
                 </TableCell>
-                <TableCell align="right">
-                  {!row.revokedAt && (
-                    <Tooltip
-                      title={translate(
-                        'resources.user.actions.revokeAppPassword',
-                      )}
-                    >
-                      <IconButton
-                        size="small"
-                        onClick={() => handleRevoke(row.id)}
-                      >
-                        <DeleteOutlineIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  )}
+                <TableCell>
+                  {translate('resources.user.fields.appPasswordCreatedAt')}
                 </TableCell>
+                <TableCell>
+                  {translate('resources.user.fields.appPasswordLastUsedAt')}
+                </TableCell>
+                <TableCell>
+                  {translate('resources.user.fields.appPasswordStatus')}
+                </TableCell>
+                <TableCell align="right" />
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {items.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell>{formatDate(row.createdAt)}</TableCell>
+                  <TableCell>{formatDate(row.lastUsedAt)}</TableCell>
+                  <TableCell>
+                    {row.revokedAt
+                      ? translate('resources.user.message.appPasswordRevoked')
+                      : translate('resources.user.message.appPasswordActive')}
+                  </TableCell>
+                  <TableCell align="right">
+                    {!row.revokedAt && (
+                      <Tooltip
+                        title={translate(
+                          'resources.user.actions.revokeAppPassword',
+                        )}
+                      >
+                        <IconButton
+                          size="small"
+                          onClick={() => setRevokeTarget(row)}
+                        >
+                          <DeleteOutlineIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       )}
 
       <Dialog
@@ -252,28 +287,57 @@ export const AppPasswordPanel = ({ userId }) => {
             {translate('resources.user.message.appPasswordOneTime')}
           </DialogContentText>
           {generated && (
-            <>
-              <TextField
-                value={generated.secret}
-                className={classes.secretField}
-                InputProps={{ readOnly: true }}
-                onFocus={(e) => e.target.select()}
-                multiline
-              />
-              <Box className={classes.secretActions}>
-                <Button
-                  startIcon={<FileCopyIcon />}
-                  onClick={() => handleCopy(generated.secret)}
-                >
-                  {translate('resources.user.actions.copyAppPassword')}
-                </Button>
+            <Tooltip
+              title={translate('resources.user.message.appPasswordClickToCopy')}
+              placement="top"
+            >
+              <Box
+                component="div"
+                role="button"
+                tabIndex={0}
+                aria-label={translate(
+                  'resources.user.message.appPasswordClickToCopy',
+                )}
+                className={classes.secret}
+                onClick={() => handleCopy(generated.secret)}
+                onKeyDown={handleSecretKeyDown(generated.secret)}
+              >
+                {generated.secret}
               </Box>
-            </>
+            </Tooltip>
           )}
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setGenerated(null)} color="primary">
             {translate('ra.action.close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={!!revokeTarget}
+        onClose={() => !revoking && setRevokeTarget(null)}
+      >
+        <DialogTitle>
+          {translate('resources.user.message.appPasswordConfirmRevokeTitle')}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {translate('resources.user.message.appPasswordConfirmRevokeBody', {
+              name: revokeTarget?.name || '',
+            })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRevokeTarget(null)} disabled={revoking}>
+            {translate('ra.action.cancel')}
+          </Button>
+          <Button
+            onClick={handleRevokeConfirmed}
+            color="secondary"
+            disabled={revoking}
+          >
+            {translate('resources.user.actions.revokeAppPassword')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/ui/src/user/AppPasswordPanel.test.jsx
+++ b/ui/src/user/AppPasswordPanel.test.jsx
@@ -19,8 +19,8 @@ vi.mock('@material-ui/core/styles', () => ({
     root: '',
     header: '',
     empty: '',
-    secretField: '',
-    secretActions: '',
+    tableWrap: '',
+    secret: '',
   }),
 }))
 
@@ -96,6 +96,7 @@ vi.mock('@material-ui/core', () => {
     Table: passthrough('table', 'MockTable'),
     TableBody: passthrough('tbody', 'MockTableBody'),
     TableCell: passthrough('td', 'MockTableCell'),
+    TableContainer: passthrough('div', 'MockTableContainer'),
     TableHead: passthrough('thead', 'MockTableHead'),
     TableRow: passthrough('tr', 'MockTableRow'),
     Typography: passthrough('div', 'MockTypography'),
@@ -115,11 +116,6 @@ vi.mock('@material-ui/icons/DeleteOutline', () => {
   const MockDeleteOutlineIcon = () => React.createElement('span', null, 'del')
   MockDeleteOutlineIcon.displayName = 'MockDeleteOutlineIcon'
   return { default: MockDeleteOutlineIcon }
-})
-vi.mock('@material-ui/icons/FileCopy', () => {
-  const MockFileCopyIcon = () => React.createElement('span', null, 'cp')
-  MockFileCopyIcon.displayName = 'MockFileCopyIcon'
-  return { default: MockFileCopyIcon }
 })
 
 vi.mock('../consts', () => ({
@@ -191,11 +187,40 @@ describe('<AppPasswordPanel />', () => {
     fireEvent.click(screen.getByTestId('btn-ra.action.create'))
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue('super-secret-123')).toBeInTheDocument()
+      expect(screen.getByText('super-secret-123')).toBeInTheDocument()
     })
   })
 
-  it('calls the revoke endpoint when the per-row revoke button is clicked', async () => {
+  it('copies the secret to the clipboard when the secret element is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    httpClient
+      .mockResolvedValueOnce({ json: [] })
+      .mockResolvedValueOnce({
+        json: { id: 'ap1', name: 'X', secret: 'click-to-copy-me' },
+      })
+      .mockResolvedValueOnce({ json: [] })
+
+    render(<AppPasswordPanel userId="user-1" />)
+    await waitFor(() => expect(httpClient).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(
+      screen.getByTestId('btn-resources.user.actions.generateAppPassword'),
+    )
+    fireEvent.change(
+      screen.getByTestId('tf-resources.user.fields.appPasswordName'),
+      { target: { value: 'Phone' } },
+    )
+    fireEvent.click(screen.getByTestId('btn-ra.action.create'))
+
+    const secret = await screen.findByText('click-to-copy-me')
+    fireEvent.click(secret)
+
+    expect(writeText).toHaveBeenCalledWith('click-to-copy-me')
+  })
+
+  it('requires confirmation before revoking an app password', async () => {
     httpClient
       .mockResolvedValueOnce({
         json: [
@@ -214,7 +239,14 @@ describe('<AppPasswordPanel />', () => {
     render(<AppPasswordPanel userId="user-1" />)
     await waitFor(() => expect(screen.getByText('iPhone')).toBeInTheDocument())
 
+    // Click the trash icon — should NOT fire DELETE yet, just open the dialog.
     fireEvent.click(screen.getByTestId('icon-button'))
+    expect(httpClient).toHaveBeenCalledTimes(1) // still only the initial load
+
+    // Confirm in the dialog — that's when DELETE actually fires.
+    fireEvent.click(
+      screen.getByTestId('btn-resources.user.actions.revokeAppPassword'),
+    )
 
     await waitFor(() => {
       expect(httpClient).toHaveBeenCalledWith(
@@ -222,5 +254,27 @@ describe('<AppPasswordPanel />', () => {
         { method: 'DELETE' },
       )
     })
+  })
+
+  it('does not revoke when the confirmation dialog is cancelled', async () => {
+    httpClient.mockResolvedValueOnce({
+      json: [
+        {
+          id: 'ap1',
+          name: 'iPhone',
+          createdAt: '2026-04-27T00:00:00Z',
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ],
+    })
+
+    render(<AppPasswordPanel userId="user-1" />)
+    await waitFor(() => expect(screen.getByText('iPhone')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('icon-button'))
+    fireEvent.click(screen.getByTestId('btn-ra.action.cancel'))
+
+    expect(httpClient).toHaveBeenCalledTimes(1) // no DELETE issued
   })
 })


### PR DESCRIPTION
## Summary

Three UX fixes on the Security pane App Passwords UI from PR #21, plus a small visual sweep:

1. **Click-to-copy on the secret.** Replaces the separate `COPY` button with click-on-the-password-itself, wrapped in a "Click to copy" tooltip. Keyboard-accessible (`role="button"`, `tabIndex=0`, Enter/Space activation).
2. **Table no longer runs off the side.** Wrapped the App Passwords `<Table>` in a `TableContainer` with `overflowX:auto`, and added `flexWrap`+`gap` to the header row so the **Generate App Password** button drops below the heading at narrow widths instead of pushing past the viewport.
3. **Revoke now requires confirmation.** Trash-icon click opens a confirm dialog with the password's name interpolated into the body — the `DELETE` only fires after the user clicks Revoke in the dialog. Cancel path verified by a new test.

## Visual evidence (before)

- App Passwords running off the right at ~800px viewport: ![narrow](https://github.com/joestump/navidrome-ldap/releases/download/untagged-5f0a23302c22dd19a9a5/security-narrow.png)
- Secret modal with the separate COPY button: ![modal](https://github.com/joestump/navidrome-ldap/releases/download/untagged-5f0a23302c22dd19a9a5/secret-modal-before.png)
- Security pane at full width: ![pane](https://github.com/joestump/navidrome-ldap/releases/download/untagged-5f0a23302c22dd19a9a5/security-pane-before.png)

## Sweep

Reviewed every file PR #21 touched (`SecurityMenu.jsx`, `Security.jsx`, `UserEdit.jsx`, `AppBar.jsx`) — no other visual issues spotted. The Security menu item, locked LDAP fields, and routing all render correctly.

## i18n

New keys: `appPasswordClickToCopy`, `appPasswordConfirmRevokeTitle`, `appPasswordConfirmRevokeBody` (with `%{name}` interpolation).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 55 files / 497 tests passing (4 existing AppPasswordPanel specs adapted to the new flows; 2 new specs cover click-to-copy and the revoke-cancel path)
- [x] `npm run build` clean
- [ ] Verify in deployed UI on `navidrome.stump.rocks` after merge + redeploy with `-e service_pull=always` (the `:develop` floating-tag pull trap; tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)