### PR TITLE
fix(ui): one info Alert for LDAP-managed account, drop redundant per-field copy

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -164,8 +164,7 @@
       },
       "helperTexts": {
         "name": "Changes to your name will only be reflected on next login",
-        "libraries": "Select specific libraries for this user, or leave empty to use default libraries",
-        "ldapManagedField": "Managed by LDAP — overwritten on every login"
+        "libraries": "Select specific libraries for this user, or leave empty to use default libraries"
       },
       "notifications": {
         "created": "User created",
@@ -199,7 +198,7 @@
         "appPasswordClickToCopy": "Click to copy",
         "appPasswordConfirmRevokeTitle": "Revoke app password?",
         "appPasswordConfirmRevokeBody": "Any device or app using \"%{name}\" will stop working immediately. This cannot be undone.",
-        "ldapManagedPassword": "This account authenticates against LDAP. Sign in with your directory password; for Subsonic clients, generate an app password from the Security page."
+        "ldapManagedAccount": "This account is managed by LDAP. Username and name are refreshed from your directory on every login. Sign in with your directory password; for Subsonic-compatible clients, generate an app password on the Security page."
       }
     },
     "player": {

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -21,17 +21,22 @@ import {
   useRecordContext,
 } from 'react-admin'
 import { Typography } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
 import { Title } from '../common'
 import DeleteUserButton from './DeleteUserButton'
 import { LibrarySelectionField } from './LibrarySelectionField.jsx'
 import { validateUserForm } from './userValidation'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   toolbar: {
     display: 'flex',
     justifyContent: 'space-between',
   },
-})
+  ldapAlert: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+  },
+}))
 
 const UserTitle = ({ record }) => {
   const translate = useTranslate()
@@ -75,11 +80,10 @@ const UserEdit = (props) => {
 
   const isMyself = props.id === localStorage.getItem('userId')
   const canDelete = permissions === 'admin' && !isMyself
-  const nameHelperText = (ldap) => {
-    if (ldap) return translate('resources.user.helperTexts.ldapManagedField')
-    if (isMyself) return translate('resources.user.helperTexts.name')
-    return undefined
-  }
+  const classes = useStyles()
+  const nameHelperText = isMyself
+    ? translate('resources.user.helperTexts.name')
+    : undefined
 
   const save = useCallback(
     async (values) => {
@@ -122,33 +126,36 @@ const UserEdit = (props) => {
           {({ formData }) => {
             const ldap = formData.authType === 'ldap'
             // For LDAP-backed users the directory is the source of
-            // truth — userName and name get rewritten on every login
-            // from the LDAP attributes, so editing them locally is at
-            // best transient and at worst confusing. Render them
-            // disabled (admins still see the field, but can't change
-            // it) so it's clear why.
+            // truth — userName, name, and password live there, so
+            // editing them locally is at best transient. One Alert at
+            // the top of the form explains the whole shape; userName
+            // and name are rendered disabled (admins still see the
+            // field, but can't change it) and the password block is
+            // omitted entirely.
             return (
               <>
+                {ldap && (
+                  <Alert
+                    severity="info"
+                    variant="outlined"
+                    className={classes.ldapAlert}
+                  >
+                    {translate('resources.user.message.ldapManagedAccount')}
+                  </Alert>
+                )}
                 {permissions === 'admin' && (
                   <TextInput
                     spellCheck={false}
                     source="userName"
                     validate={[required()]}
                     disabled={ldap}
-                    helperText={
-                      ldap
-                        ? translate(
-                            'resources.user.helperTexts.ldapManagedField',
-                          )
-                        : undefined
-                    }
                   />
                 )}
                 <TextInput
                   source="name"
                   validate={[required()]}
                   disabled={ldap}
-                  helperText={nameHelperText(ldap)}
+                  helperText={ldap ? undefined : nameHelperText}
                 />
               </>
             )
@@ -157,15 +164,7 @@ const UserEdit = (props) => {
         <TextInput spellCheck={false} source="email" validate={[email()]} />
         <FormDataConsumer>
           {({ formData }) =>
-            formData.authType === 'ldap' ? (
-              <Typography
-                variant="body2"
-                color="textSecondary"
-                style={{ marginTop: 16, marginBottom: 16 }}
-              >
-                {translate('resources.user.message.ldapManagedPassword')}
-              </Typography>
-            ) : (
+            formData.authType === 'ldap' ? null : (
               <>
                 <BooleanInput source="changePassword" />
                 <CurrentPasswordInput

--- a/ui/src/user/UserEdit.test.jsx
+++ b/ui/src/user/UserEdit.test.jsx
@@ -92,6 +92,14 @@ vi.mock('@material-ui/core', () => ({
   Typography: ({ children }) => <p>{children}</p>,
 }))
 
+vi.mock('@material-ui/lab', () => ({
+  Alert: ({ children, severity }) => (
+    <div role="alert" data-severity={severity}>
+      {children}
+    </div>
+  ),
+}))
+
 describe('<UserEdit />', () => {
   it('should render the user edit form', () => {
     render(<UserEdit id="user1" permissions="admin" />)
@@ -158,12 +166,14 @@ describe('<UserEdit />', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('shows the LDAP-managed-password explainer', () => {
+    it('shows the combined LDAP-managed-account info Alert at the top of the form', () => {
       render(<UserEdit id="user1" permissions="admin" />)
 
-      expect(
-        screen.getByText('resources.user.message.ldapManagedPassword'),
-      ).toBeInTheDocument()
+      const alert = screen.getByRole('alert')
+      expect(alert).toHaveAttribute('data-severity', 'info')
+      expect(alert).toHaveTextContent(
+        'resources.user.message.ldapManagedAccount',
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

The User edit form had two LDAP-managed-account explainers that said roughly the same thing in two different places:

1. A per-field helper text under userName/name: *"Managed by LDAP — overwritten on every login"*.
2. A standalone Typography paragraph in place of the password block: *"This account authenticates against LDAP. Sign in with your directory password; for Subsonic clients, generate an app password from the Security page."*

Replaced both with a single Material UI `<Alert severity="info" variant="outlined">` at the top of the form, only rendered when `authType === 'ldap'`. The combined copy:

> This account is managed by LDAP. Username and name are refreshed from your directory on every login. Sign in with your directory password; for Subsonic-compatible clients, generate an app password on the Security page.

The disabled visual state of the userName/name fields stands on its own; the password block is simply omitted for LDAP users (no Typography placeholder).

## i18n changes

- Removed: `resources.user.helperTexts.ldapManagedField`, `resources.user.message.ldapManagedPassword`
- Added: `resources.user.message.ldapManagedAccount`

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 55 files / 497 tests passing (one UserEdit spec adjusted to assert `role="alert"` + `data-severity="info"` instead of the old paragraph)
- [x] `npm run build` clean
- [ ] Verify in deployed UI on `navidrome.stump.rocks` after merge + redeploy with `-e service_pull=always`

🤖 Generated with [Claude Code](https://claude.com/claude-code)