### PR TITLE
fix(ldap-admin): validate AdminFilter at startup, cover login admin-recompute with unit test

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -419,6 +419,7 @@ func Load(noConfigDump bool) {
 		validateScanSchedule,
 		validateBackupSchedule,
 		validateLDAPLivenessSchedule,
+		validateLDAPAdminFilter,
 		validatePlaylistsPath,
 		validatePurgeMissingOption,
 		validateMaxImageUploadSize,
@@ -682,6 +683,19 @@ func validateLDAPLivenessSchedule() error {
 	var err error
 	Server.LDAP.LivenessSchedule, err = validateSchedule(Server.LDAP.LivenessSchedule, "LDAP.LivenessSchedule")
 	return err
+}
+
+// validateLDAPAdminFilter refuses to start when LDAP.AdminFilter is
+// configured but missing the `%s` placeholder. Without it, fmt.Sprintf
+// silently produces a malformed filter (e.g.
+// `(memberOf=cn=admins,...)%!(EXTRA string=alice)`) which only surfaces
+// at runtime as repeated "LDAP admin lookup failed" warnings — the kind
+// of silent breakage that's better caught at startup.
+func validateLDAPAdminFilter() error {
+	if af := Server.LDAP.AdminFilter; af != "" && !strings.Contains(af, "%s") {
+		return fmt.Errorf("ND_LDAP_ADMINFILTER must contain %%s placeholder for the username")
+	}
+	return nil
 }
 
 func validateBackupSchedule() error {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -250,6 +250,41 @@ var _ = Describe("Configuration", func() {
 		)
 	})
 
+	Describe("ValidateLDAPAdminFilter", func() {
+		BeforeEach(func() {
+			viper.Reset()
+			conf.SetViperDefaults()
+			viper.SetDefault("datafolder", GinkgoT().TempDir())
+			viper.SetDefault("loglevel", "error")
+			conf.ResetConf()
+		})
+
+		It("accepts an empty AdminFilter (feature off)", func() {
+			conf.Server.LDAP.AdminFilter = ""
+			Expect(conf.ValidateLDAPAdminFilter()).To(Succeed())
+		})
+
+		It("accepts an AdminFilter that contains %s", func() {
+			conf.Server.LDAP.AdminFilter = "(&(memberOf=cn=admins,dc=example,dc=org)(uid=%s))"
+			Expect(conf.ValidateLDAPAdminFilter()).To(Succeed())
+		})
+
+		It("rejects a non-empty AdminFilter that is missing %s", func() {
+			conf.Server.LDAP.AdminFilter = "(memberOf=cn=admins,dc=example,dc=org)"
+			err := conf.ValidateLDAPAdminFilter()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ND_LDAP_ADMINFILTER"))
+			Expect(err.Error()).To(ContainSubstring("%s"))
+		})
+
+		It("fails Load when AdminFilter is missing %s", func() {
+			viper.Set("ldap.adminfilter", "(memberOf=cn=admins,dc=example,dc=org)")
+			Expect(func() {
+				conf.Load(true)
+			}).To(PanicWith(ContainSubstring("ND_LDAP_ADMINFILTER")))
+		})
+	})
+
 	Describe("EnforceNonRootUser", func() {
 		It("defaults to false", func() {
 			conf.Load(true)

--- a/conf/export_test.go
+++ b/conf/export_test.go
@@ -16,6 +16,8 @@ var ToPascalCase = toPascalCase
 
 var ValidateMaxImageUploadSize = validateMaxImageUploadSize
 
+var ValidateLDAPAdminFilter = validateLDAPAdminFilter
+
 func SetRuntimeInfoForTest(goos string, euid int) func() {
 	oldGOOS := currentGOOS
 	oldEUID := getEUID

--- a/server/auth.go
+++ b/server/auth.go
@@ -269,9 +269,7 @@ func validateLoginLDAP(userRepo model.UserRepository, userName, password string)
 	u.Name = entry.GetAttributeValue(nameAttr)
 	u.Email = entry.GetAttributeValue(mailAttr)
 	u.AuthType = model.AuthTypeLDAP
-	if adminCheckResult != nil {
-		u.IsAdmin = *adminCheckResult
-	}
+	applyLDAPAdminResult(u, adminCheckResult)
 	if err := userRepo.Put(u); err != nil {
 		log.Error("Could not save LDAP user", "user", userName, err)
 		return nil, nil

--- a/server/ldap_admin.go
+++ b/server/ldap_admin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-ldap/ldap"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model"
 )
 
 // adminCheckEnabled reports whether the operator has configured an
@@ -55,4 +56,16 @@ func ldapAdminCheck(l *ldap.Conn, userName string) (isAdmin bool, err error) {
 		return false, err
 	}
 	return len(sr.Entries) > 0, nil
+}
+
+// applyLDAPAdminResult applies the outcome of an admin-membership lookup
+// to the user's IsAdmin flag. A nil result means the lookup was skipped
+// (admin policy not configured) or failed transiently — in both cases
+// the existing IsAdmin is preserved so a directory hiccup can't lock the
+// operator out. A non-nil pointer is the authoritative result and
+// overwrites IsAdmin in either direction (promote or demote).
+func applyLDAPAdminResult(u *model.User, adminCheckResult *bool) {
+	if adminCheckResult != nil {
+		u.IsAdmin = *adminCheckResult
+	}
 }

--- a/server/ldap_admin_test.go
+++ b/server/ldap_admin_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -92,6 +93,39 @@ var _ = Describe("LDAP admin filter construction", func() {
 			conf.Server.LDAP.AdminFilter = "(uid=%s)"
 
 			Expect(buildAdminFilter("alice")).To(ContainSubstring("memberOf=cn=admins"))
+		})
+	})
+
+	Describe("applyLDAPAdminResult", func() {
+		It("preserves IsAdmin when result is nil (lookup skipped or transient error)", func() {
+			adminUser := &model.User{IsAdmin: true}
+			applyLDAPAdminResult(adminUser, nil)
+			Expect(adminUser.IsAdmin).To(BeTrue())
+
+			regularUser := &model.User{IsAdmin: false}
+			applyLDAPAdminResult(regularUser, nil)
+			Expect(regularUser.IsAdmin).To(BeFalse())
+		})
+
+		It("promotes the user when result points to true", func() {
+			u := &model.User{IsAdmin: false}
+			result := true
+			applyLDAPAdminResult(u, &result)
+			Expect(u.IsAdmin).To(BeTrue())
+		})
+
+		It("demotes the user when result points to false", func() {
+			u := &model.User{IsAdmin: true}
+			result := false
+			applyLDAPAdminResult(u, &result)
+			Expect(u.IsAdmin).To(BeFalse())
+		})
+
+		It("is a no-op when the result matches the existing value", func() {
+			u := &model.User{IsAdmin: true}
+			result := true
+			applyLDAPAdminResult(u, &result)
+			Expect(u.IsAdmin).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Two small follow-ups from the PR #16 review, bundled because they touch the same feature surface (LDAP admin-group → IsAdmin mapping) and are independently small.

1. **Validate `ND_LDAP_ADMINFILTER` at startup.** If the operator sets `AdminFilter` without including `%s`, `fmt.Sprintf(af, escaped)` returns a malformed filter (`(memberOf=...)%!(EXTRA string=alice)`). The admin search fails on every login and every liveness tick, the failsafe preserves IsAdmin, and the only signal is repeated `LDAP admin lookup failed` warnings in logs. A startup validator catches this in seconds: `validateLDAPAdminFilter` refuses to start when `AdminFilter` is non-empty and missing `%s`, with an error that names the env var. Registered alongside `validateLDAPLivenessSchedule` in the `run.Sequentially` chain.

2. **Unit-test the login admin-recompute apply step.** The post-bind admin-application block in `validateLoginLDAP` had no direct test — existing LDAP-login tests only cover `Host empty` and connection-failure paths, neither of which reaches the new admin code. Extracted the three-line apply into a pure helper `applyLDAPAdminResult(u *model.User, adminCheckResult *bool)` and unit-tested all three cases (nil → preserve, `&true` → promote, `&false` → demote). Same line of code, just relocated to a testable helper — **no production behavior change.**

## Test plan

- [x] `make lint` clean (`0 issues.`)
- [x] `make test` clean — full Go suite passes
- [x] New conf tests cover empty filter, valid filter (with `%s`), invalid filter (rejected with error mentioning `ND_LDAP_ADMINFILTER` + `%s`), and end-to-end `Load` panic path.
- [x] New `applyLDAPAdminResult` tests cover nil-preserves-existing (both true and false starting states), `&true` promotes, `&false` demotes.

## Closes

- Closes #18
- Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)