### PR TITLE
fix(ldap-liveness): probe cleanup — skip dial on empty user set, gate noisy log, extract filter helpers

### DIFF
--- a/server/ldap_liveness.go
+++ b/server/ldap_liveness.go
@@ -43,6 +43,21 @@ func LDAPLivenessCheck(ctx context.Context, ds model.DataStore) {
 		return
 	}
 
+	// Load LDAP-backed users before dialing so we don't burn a TCP+TLS
+	// handshake + bind on every tick when there's nothing to reconcile
+	// (just-after-rollout, mostly-local installs that enabled the feature
+	// speculatively, etc.).
+	users, err := ds.User(ctx).GetAll(model.QueryOptions{
+		Filters: squirrel.Eq{"auth_type": model.AuthTypeLDAP},
+	})
+	if err != nil {
+		log.Error(ctx, "LDAP liveness: failed to load LDAP users", err)
+		return
+	}
+	if len(users) == 0 {
+		return
+	}
+
 	l, err := ldap.DialURL(conf.Server.LDAP.Host)
 	if err != nil {
 		log.Warn(ctx, "LDAP liveness: dial failed; skipping run", "host", conf.Server.LDAP.Host, err)
@@ -61,23 +76,16 @@ func LDAPLivenessCheck(ctx context.Context, ds model.DataStore) {
 			return ldapAdminCheck(l, userName)
 		}
 	}
-	runLDAPLivenessCheck(ctx, ds, ldapProbe(l), adminProbe)
+	runLDAPLivenessCheck(ctx, ds, ldapProbe(l), adminProbe, users)
 }
 
-// runLDAPLivenessCheck is the testable core: given a probe, walk every
-// LDAP-backed user and revoke app passwords for ones that don't pass.
-// When adminProbe is non-nil, IsAdmin is also recomputed against the
-// directory and persisted on change. A transient adminProbe error
-// preserves the existing IsAdmin rather than demoting.
-func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenessProbe, adminProbe adminProbeFn) {
-	userRepo := ds.User(ctx)
-	users, err := userRepo.GetAll(model.QueryOptions{
-		Filters: squirrel.Eq{"auth_type": model.AuthTypeLDAP},
-	})
-	if err != nil {
-		log.Error(ctx, "LDAP liveness: failed to load LDAP users", err)
-		return
-	}
+// runLDAPLivenessCheck is the testable core: given a probe and a
+// pre-loaded set of LDAP users, walk every user and revoke app
+// passwords for ones that don't pass. When adminProbe is non-nil,
+// IsAdmin is also recomputed against the directory and persisted on
+// change. A transient adminProbe error preserves the existing IsAdmin
+// rather than demoting.
+func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenessProbe, adminProbe adminProbeFn, users model.Users) {
 	if len(users) == 0 {
 		return
 	}
@@ -87,9 +95,9 @@ func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenes
 	revoked := 0
 	adminChanged := 0
 	for _, u := range users {
-		// Defense-in-depth: the SQL filter above should have done this,
-		// but never revoke a local user's app passwords just because a
-		// future caller forgot to scope the query.
+		// Defense-in-depth: the SQL filter at the call site should have
+		// done this, but never revoke a local user's app passwords just
+		// because a future caller forgot to scope the query.
 		if !u.IsLDAP() {
 			continue
 		}
@@ -106,8 +114,14 @@ func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenes
 				log.Error(ctx, "LDAP liveness: failed to revoke app passwords", "user", u.UserName, revokeErr)
 			} else {
 				revoked++
-				log.Info(ctx, "LDAP liveness: revoked app passwords for user no longer authorized",
-					"user", u.UserName, "reason", reason, "appPasswords", n)
+				if n > 0 {
+					// Only log the "revoked" line when there was actually
+					// something to revoke. Otherwise an offboarding wave on
+					// a directory with few app-password users floods INFO
+					// with "appPasswords=0" lines on every tick.
+					log.Info(ctx, "LDAP liveness: revoked app passwords for user no longer authorized",
+						"user", u.UserName, "reason", reason, "appPasswords", n)
+				}
 			}
 		}
 
@@ -135,13 +149,35 @@ func runLDAPLivenessCheck(ctx context.Context, ds model.DataStore, probe livenes
 		"users", len(users), "checked", checked, "revoked", revoked, "adminChanged", adminChanged)
 }
 
+// presenceFilter builds the "does this user exist?" LDAP filter by
+// substituting the escaped username into the configured SearchFilter
+// template (e.g. "(uid=%s)"). The username is run through
+// ldap.EscapeFilter to neutralize filter metacharacters before
+// substitution.
+func presenceFilter(userName string) string {
+	return fmt.Sprintf(conf.Server.LDAP.SearchFilter, ldap.EscapeFilter(userName))
+}
+
+// disabledFilter builds the "is this user disabled?" LDAP filter by
+// AND-ing the configured DisabledFilter clause onto the presence
+// filter for the given username. Returns "" when DisabledFilter is
+// empty — the caller should skip the disabled-check search in that
+// case.
+func disabledFilter(userName string) string {
+	df := conf.Server.LDAP.DisabledFilter
+	if df == "" {
+		return ""
+	}
+	return "(&" + presenceFilter(userName) + df + ")"
+}
+
 // ldapProbe builds a livenessProbe that consults the given LDAP
 // connection. The connection must already be bound as the service
 // account.
 func ldapProbe(l *ldap.Conn) livenessProbe {
 	return func(userName string) (active bool, reason string, err error) {
 		base := conf.Server.LDAP.Base
-		userFilter := fmt.Sprintf(conf.Server.LDAP.SearchFilter, ldap.EscapeFilter(userName))
+		userFilter := presenceFilter(userName)
 
 		// Does the user exist in the directory at all?
 		sr, err := l.Search(ldap.NewSearchRequest(
@@ -159,11 +195,10 @@ func ldapProbe(l *ldap.Conn) livenessProbe {
 		// Don't penalize the user for a transient search error here:
 		// assume active and reconcile on the next tick rather than
 		// revoking based on a flaky directory response.
-		if df := conf.Server.LDAP.DisabledFilter; df != "" {
-			disabledFilter := "(&" + userFilter + df + ")"
+		if df := disabledFilter(userName); df != "" {
 			sr2, searchErr := l.Search(ldap.NewSearchRequest(
 				base, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-				disabledFilter, []string{"dn"}, nil,
+				df, []string{"dn"}, nil,
 			))
 			if searchErr == nil && len(sr2.Entries) > 0 {
 				return false, "disabled", nil

--- a/server/ldap_liveness_test.go
+++ b/server/ldap_liveness_test.go
@@ -3,31 +3,41 @@ package server
 import (
 	"context"
 	"errors"
+	"strings"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("LDAP liveness check", func() {
 	var (
-		ds       *tests.MockDataStore
-		users    model.UserRepository
-		appPwds  model.AppPasswordRepository
-		original string
+		ds               *tests.MockDataStore
+		users            model.UserRepository
+		appPwds          model.AppPasswordRepository
+		originalHost     string
+		originalSearch   string
+		originalDisabled string
 	)
 
 	BeforeEach(func() {
 		ds = &tests.MockDataStore{}
 		users = ds.User(context.Background())
 		appPwds = ds.AppPassword(context.Background())
-		original = conf.Server.LDAP.Host
+		originalHost = conf.Server.LDAP.Host
+		originalSearch = conf.Server.LDAP.SearchFilter
+		originalDisabled = conf.Server.LDAP.DisabledFilter
 	})
 
 	AfterEach(func() {
-		conf.Server.LDAP.Host = original
+		conf.Server.LDAP.Host = originalHost
+		conf.Server.LDAP.SearchFilter = originalSearch
+		conf.Server.LDAP.DisabledFilter = originalDisabled
 	})
 
 	// Helper: seed one LDAP user with one active app password.
@@ -52,6 +62,16 @@ var _ = Describe("LDAP liveness check", func() {
 		return len(active)
 	}
 
+	// Helper: load every LDAP-backed user from the mock store, mirroring
+	// the production query in LDAPLivenessCheck.
+	loadLDAPUsers := func() model.Users {
+		out, err := ds.User(context.Background()).GetAll(model.QueryOptions{
+			Filters: squirrel.Eq{"auth_type": model.AuthTypeLDAP},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		return out
+	}
+
 	Context("LDAPLivenessCheck top-level", func() {
 		It("is a no-op when LDAP.Host is not configured", func() {
 			conf.Server.LDAP.Host = ""
@@ -60,6 +80,17 @@ var _ = Describe("LDAP liveness check", func() {
 			LDAPLivenessCheck(context.Background(), ds)
 
 			Expect(activeCount("u1")).To(Equal(1))
+		})
+
+		It("does not dial LDAP when there are no LDAP-backed users", func() {
+			// Pointing at an unresolvable host would fail the run if a
+			// dial were attempted; instead, the user-load short-circuits
+			// before dial and the run completes cleanly.
+			conf.Server.LDAP.Host = "ldap://invalid-host-that-does-not-resolve:389"
+
+			Expect(func() {
+				LDAPLivenessCheck(context.Background(), ds)
+			}).ToNot(Panic())
 		})
 
 		It("aborts the run on dial failure without revoking anything", func() {
@@ -83,7 +114,7 @@ var _ = Describe("LDAP liveness check", func() {
 				}
 				return true, "", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, loadLDAPUsers())
 
 			Expect(activeCount("u-missing")).To(Equal(0))
 			Expect(activeCount("u-active")).To(Equal(1))
@@ -95,7 +126,7 @@ var _ = Describe("LDAP liveness check", func() {
 			probe := func(name string) (bool, string, error) {
 				return false, "disabled", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, loadLDAPUsers())
 
 			Expect(activeCount("u-disabled")).To(Equal(0))
 		})
@@ -106,7 +137,7 @@ var _ = Describe("LDAP liveness check", func() {
 			probe := func(name string) (bool, string, error) {
 				return false, "", errors.New("transient ldap search failure")
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, loadLDAPUsers())
 
 			Expect(activeCount("u-flaky")).To(Equal(1))
 		})
@@ -123,24 +154,85 @@ var _ = Describe("LDAP liveness check", func() {
 				NewPassword: "local-app",
 			})).To(Succeed())
 
+			// Pass every user (LDAP and local) directly, simulating a future
+			// caller that forgot to scope by auth_type.
+			everyone, err := users.GetAll()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Probe says "missing" for everyone — should still spare the local user.
 			probe := func(name string) (bool, string, error) {
 				return false, "missing", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, everyone)
 
 			Expect(activeCount("u-local")).To(Equal(1))
 		})
 
-		It("is a no-op when no LDAP users are present", func() {
+		It("is a no-op when no LDAP users are passed in", func() {
 			probeCalls := 0
 			probe := func(name string) (bool, string, error) {
 				probeCalls++
 				return true, "", nil
 			}
-			runLDAPLivenessCheck(context.Background(), ds, probe, nil)
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, nil)
 
 			Expect(probeCalls).To(Equal(0))
+		})
+
+		It("does not log the revoke line when the user had zero app passwords", func() {
+			// Seed a user with no app passwords at all.
+			Expect(users.Put(&model.User{
+				ID:       "u-no-app-pwds",
+				UserName: "lonely",
+				AuthType: model.AuthTypeLDAP,
+			})).To(Succeed())
+			Expect(users.ClearPassword("u-no-app-pwds")).To(Succeed())
+
+			hook, cleanup := tests.LogHook()
+			defer cleanup()
+			log.SetLevel(log.LevelInfo)
+
+			probe := func(name string) (bool, string, error) {
+				return false, "missing", nil
+			}
+
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, loadLDAPUsers())
+
+			Expect(activeCount("u-no-app-pwds")).To(Equal(0))
+
+			// No INFO log line about "revoked app passwords" should fire
+			// when n == 0 — that line is misleading and noisy on
+			// directories with users that never generated app passwords.
+			for _, e := range hook.AllEntries() {
+				if e.Level == logrus.InfoLevel {
+					Expect(e.Message).ToNot(ContainSubstring("revoked app passwords"))
+				}
+			}
+		})
+
+		It("logs the revoke line when at least one app password was revoked", func() {
+			seedLDAPUser("u-bye", "bye")
+
+			hook, cleanup := tests.LogHook()
+			defer cleanup()
+			log.SetLevel(log.LevelInfo)
+
+			probe := func(name string) (bool, string, error) {
+				return false, "missing", nil
+			}
+
+			runLDAPLivenessCheck(context.Background(), ds, probe, nil, loadLDAPUsers())
+
+			Expect(activeCount("u-bye")).To(Equal(0))
+
+			matched := false
+			for _, e := range hook.AllEntries() {
+				if e.Level == logrus.InfoLevel && strings.Contains(e.Message, "revoked app passwords") {
+					matched = true
+					break
+				}
+			}
+			Expect(matched).To(BeTrue(), "expected INFO log line about revoked app passwords")
 		})
 	})
 
@@ -153,7 +245,7 @@ var _ = Describe("LDAP liveness check", func() {
 			seedLDAPUser("u-promote", "promote-me")
 			adminProbe := func(name string) (bool, error) { return true, nil }
 
-			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe, loadLDAPUsers())
 
 			got, err := users.Get("u-promote")
 			Expect(err).ToNot(HaveOccurred())
@@ -169,7 +261,7 @@ var _ = Describe("LDAP liveness check", func() {
 			})).To(Succeed())
 			adminProbe := func(name string) (bool, error) { return false, nil }
 
-			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe, loadLDAPUsers())
 
 			got, err := users.Get("u-demote")
 			Expect(err).ToNot(HaveOccurred())
@@ -187,7 +279,7 @@ var _ = Describe("LDAP liveness check", func() {
 				return false, errors.New("transient ldap admin lookup failure")
 			}
 
-			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe)
+			runLDAPLivenessCheck(context.Background(), ds, alwaysActive, adminProbe, loadLDAPUsers())
 
 			got, err := users.Get("u-flaky-admin")
 			Expect(err).ToNot(HaveOccurred())
@@ -207,12 +299,53 @@ var _ = Describe("LDAP liveness check", func() {
 			missing := func(name string) (bool, string, error) { return false, "missing", nil }
 			adminProbe := func(name string) (bool, error) { return false, nil }
 
-			runLDAPLivenessCheck(context.Background(), ds, missing, adminProbe)
+			runLDAPLivenessCheck(context.Background(), ds, missing, adminProbe, loadLDAPUsers())
 
 			got, err := users.Get("u-gone-admin")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(got.IsAdmin).To(BeFalse())
 			Expect(activeCount("u-gone-admin")).To(Equal(0))
+		})
+	})
+
+	Context("filter helpers", func() {
+		BeforeEach(func() {
+			conf.Server.LDAP.SearchFilter = "(uid=%s)"
+			conf.Server.LDAP.DisabledFilter = ""
+		})
+
+		Describe("presenceFilter", func() {
+			It("substitutes a plain username into SearchFilter", func() {
+				Expect(presenceFilter("alice")).To(Equal("(uid=alice)"))
+			})
+
+			It("escapes filter metacharacters in the username", func() {
+				// ldap.EscapeFilter renders ( ) as \28 \29 (and * as \2a, \\ as \5c, NUL as \00).
+				Expect(presenceFilter("al(ice)")).To(Equal(`(uid=al\28ice\29)`))
+				Expect(presenceFilter("a*b")).To(Equal(`(uid=a\2ab)`))
+			})
+
+			It("respects a custom SearchFilter template", func() {
+				conf.Server.LDAP.SearchFilter = "(&(objectClass=person)(sAMAccountName=%s))"
+				Expect(presenceFilter("bob")).To(Equal("(&(objectClass=person)(sAMAccountName=bob))"))
+			})
+		})
+
+		Describe("disabledFilter", func() {
+			It("returns empty when DisabledFilter is empty", func() {
+				conf.Server.LDAP.DisabledFilter = ""
+				Expect(disabledFilter("alice")).To(Equal(""))
+			})
+
+			It("ANDs DisabledFilter onto the presence filter when set", func() {
+				conf.Server.LDAP.DisabledFilter = "(loginShell=/sbin/nologin)"
+				Expect(disabledFilter("alice")).To(Equal("(&(uid=alice)(loginShell=/sbin/nologin))"))
+			})
+
+			It("escapes the username inside the AND clause", func() {
+				conf.Server.LDAP.DisabledFilter = "(loginShell=/sbin/nologin)"
+				Expect(disabledFilter("al(ice)")).To(Equal(`(&(uid=al\28ice\29)(loginShell=/sbin/nologin))`))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Three follow-ups from the PR #12 review, bundled because they all touch the same file (`server/ldap_liveness.go`) and its test suite.

1. **Skip the LDAP dial when there are no LDAP-backed users (#15).** `LDAPLivenessCheck` now loads users *before* dialing. If the result set is empty, the run returns without burning a TCP+TLS handshake + service-account bind. This matters for just-after-rollout deployments and mostly-local installs that enabled the schedule speculatively — every tick was paying for an LDAP round-trip with nothing to reconcile. The pre-loaded users slice is now passed into `runLDAPLivenessCheck` instead of being reloaded inside the loop, which also decouples the test core from the user repository.

2. **Gate the per-user "revoked app passwords" INFO line on `n > 0` (#14).** Previously every inactive LDAP user logged `"LDAP liveness: revoked app passwords for user no longer authorized" appPasswords=0` even when they never generated an app password. On a directory with a populated user set but few app-password users, an offboarding wave would flood INFO with `appPasswords=0` lines on every tick. The line now only fires when something was actually revoked.

3. **Extract `ldapProbe` filter construction into pure helpers (#13).** Pulled the filter strings out into `presenceFilter()` and `disabledFilter()`. The production probe now calls them; new tests pin down the produced filter strings for plain, escape-needed, disabled-set, and disabled-empty cases. No production behavior change — this is coverage for the spot where a typo or an `ldap.EscapeFilter` regression would otherwise sit silently.

## Test plan

- [x] `make lint` clean — 0 issues.
- [x] `make test` clean — full Go suite passes, including 142 server specs (13 existing adapted, 9 new) covering the new dial-skip path, the log gate (verified via `tests.LogHook`), and the filter helpers.
- [x] `go mod tidy` no-op.

Closes #13.
Closes #14.
Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)