### PR TITLE
docs(ldap-admin): note that demotion does not revoke library access

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ When `ND_LDAP_ADMINGROUP` (or the more flexible `ND_LDAP_ADMINFILTER`) is set, N
 > [!IMPORTANT]
 > Add your existing Navidrome admin to the configured admin group **before** enabling this feature, otherwise the next login will demote them.
 
+> [!WARNING]
+> **Demotion does not revoke library access.** Upstream Navidrome auto-grants every library to a user when they're saved with `IsAdmin == true`, but there is no symmetric revoke when admin is removed. After a demotion (whether at login or on a liveness tick), the user keeps their `user_library` rows and therefore retains access to every library the admin shortcut had silently materialized for them. The fork does not auto-clean these rows because they have no provenance metadata — operator-assigned grants and admin-auto-grants are indistinguishable, and a blanket reset would destroy explicit assignments.
+>
+> When you remove a user from the LDAP admin group (or expect a sweep tick to do it), review their library access manually in the user-edit screen and prune any rows the user shouldn't keep.
+
 ### Docker Container
 
 To use LDAP features, you must use [the fork's Docker image](https://github.com/joestump/navidrome-ldap/pkgs/container/navidrome-ldap):


### PR DESCRIPTION
## Summary

Pure-docs callout under the existing **Admin role from LDAP** section in the README, capturing a finding from the PR #16 security review.

## Why

Upstream Navidrome's `userRepository.Put` auto-grants every library to a user when saved with `IsAdmin == true`, but there is no symmetric revoke when admin is removed. PR #16 added two new automated demotion paths (login recompute + liveness sweep), so a user removed from the LDAP admin group keeps their `user_library` rows and therefore retains effective access to every library — the admin shortcut at `persistence/sql_base_repository.go` only fires when `IsAdmin` is currently true, but the materialized rows from a previous admin tenure outlive the demotion.

The fork doesn't auto-clean these rows because they have no provenance metadata — operator-assigned grants and admin-auto-grants are indistinguishable in `user_library`, so a blanket reset on demotion would destroy explicit assignments. Documenting the gap and telling operators to review manually is the conservative choice; a proper fix is an upstream design conversation.

## Closes

- Closes #17

## Test plan

- [x] No code changes; README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)